### PR TITLE
Improve content panel location system

### DIFF
--- a/client/src/content_types/chart/ChartManager.js
+++ b/client/src/content_types/chart/ChartManager.js
@@ -431,6 +431,7 @@ var ChartManager = declare(null, {
      * @param req: a color request object.
      * @param gid: the group id of the forest chain to which this coloring
      *   is meant to apply.
+     * @param uuid: the uuid of the Forest that initiated the coloring event.
      */
     handleGroupcastForestColoring: function({ req, gid, uuid }) {
         for (let forest of Object.values(this.forestsByPaneId)) {

--- a/client/src/content_types/pdf/PdfController.js
+++ b/client/src/content_types/pdf/PdfController.js
@@ -444,7 +444,9 @@ var PdfController = declare(null, {
      *   These keys define desired effects relating to selection highlights.
      *
      *   selection: {string|array} Should be either a single selection code (string) or
-     *     an array of selection codes, defining the desired highlight boxes.
+     *     an array of selection codes, defining the desired highlight boxes. A "selection code"
+     *     is the same as a "combiner code string", i.e. a string describing a combination of
+     *     boxes. (See docs on that subject elsewhere.)
      *
      *   gotosel: {string} default = 'altKey'. This should be equal to one of the keywords
      *     defined below, and controls whether we will scroll to the selection. To be precise,

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -207,6 +207,7 @@ function construct(ISE_state) {
     repoManager.activate();
     studyManager.activate();
     pdfManager.activate();
+    contentManager.activate();
 
     // Listen for window focus changes and document visibility changes.
     window.addEventListener("focus", function(){

--- a/client/src/mgr/ContentManager.js
+++ b/client/src/mgr/ContentManager.js
@@ -66,6 +66,8 @@ var ContentManager = declare(null, {
     // Types for which a study page can be loaded:
     studyPageTypes: null,
     // Content registry will map pane IDs to the info object on which that pane was initialized.
+    // Note: We do not maintain a lookup of Dijit panes themselves, because we have a `getPane()`
+    // method for that.
     contentRegistry: null,
     // This will be a mapping from content types to methods for setting up content panes
     // to hold content of that type.
@@ -455,10 +457,11 @@ var ContentManager = declare(null, {
      */
     openContentInPane: async function(info, pane) {
         await this.hub.contentLoadingOkay();
-        // Every content panel must have a uuid. This goes above and beyond Dijit's
-        // panel ids, because it's unique across windows, and across reloads.
+        // Every content pane must have a uuid. This goes above and beyond Dijit's
+        // pane ids, because it's unique across windows, and across reloads.
         // If you already supplied a uuid, we assume you have good reason,
-        // and we leave it alone. Otherwise we supply one.
+        // and we leave it alone. (For example, this happens when content is being
+        // *moved* from one window to another.) Otherwise we supply one.
         if (info.uuid === undefined) {
             info.uuid = uuid4();
         }

--- a/client/src/mgr/WindowManager.js
+++ b/client/src/mgr/WindowManager.js
@@ -291,15 +291,24 @@ export class WindowManager {
                     onClick: () => {
                         //console.log(`Move to window ${n}`, info);
                         peer.makeWindowRequest(n, 'contentManager.openContentInActiveTCReturnId', info)
-                            .then(newRelLoc => {
+                            .then(newPaneId => {
                                 const event = {
-                                    type: 'paneMove',
-                                    oldAbsLoc: `${myNumber}:${oldRelLoc}`,
-                                    newAbsLoc: `${n}:${newRelLoc}`,
+                                    type: 'movePaneToWindow',
+                                    uuid: info.uuid,
+                                    oldWindow: myNumber,
+                                    oldPaneId: oldRelLoc,
+                                    newWindow: n,
+                                    newPaneId: newPaneId,
                                 }
-                                // Must dispatch event to this window synchronously so it happens
-                                // before the pane closes. If the pane closes first, then there's no control
-                                // mapping left to update!
+                                // We used to dispatch this event in order to update our WGCM, but we no longer need
+                                // to do that, since we switched to using UUIDs to identify controlled panels.
+                                //
+                                // At this point, there are no consumers of the event. I'm keeping it
+                                // for now, because it seems potentially useful.
+                                //
+                                // It seems advisable to dispatch the event to this window synchronously, so it
+                                // happens before the pane closes. If the pane closes first, there's a good chance
+                                // this loss of information could be problematic (depending on the application).
                                 windowMgr.groupcastEvent(event, {
                                     includeSelf: true,
                                     selfSync: true,

--- a/client/src/widgets/ChartWidget.js
+++ b/client/src/widgets/ChartWidget.js
@@ -57,18 +57,18 @@ var ChartWidget = declare(PaneSpawnWidget, {
             const over = info.hovercolor.over,
                 out  = info.hovercolor.out;
             wdq.on('mouseover', () => {
-                const paneLoc = nm.getPaneLocForGroup(this.groupId);
+                const paneUuid = nm.getPaneUuidForGroup(this.groupId);
                 /* Note: whereas, when a user _clicks_ on a chart widget, we do want a controlled
                  * pane to pop up if it's not there already, on mere mouseover we do not want that.
                  * So here the behavior occurs only if there is already a controlled pane. */
-                if (paneLoc) {
-                    this.hub.contentManager.updateContent({type: "CHART", color: over}, paneLoc, { selectPane: true });
+                if (paneUuid) {
+                    this.hub.contentManager.updateContentAnywhereByUuid({type: "CHART", color: over}, paneUuid, { selectPane: true });
                 }
             });
             wdq.on('mouseout', () => {
-                const paneLoc = nm.getPaneLocForGroup(this.groupId);
-                if (paneLoc) {
-                    this.hub.contentManager.updateContent({type: "CHART", color: out}, paneLoc, { selectPane: true });
+                const paneUuid = nm.getPaneUuidForGroup(this.groupId);
+                if (paneUuid) {
+                    this.hub.contentManager.updateContentAnywhereByUuid({type: "CHART", color: out}, paneUuid, { selectPane: true });
                 }
             });
         }


### PR DESCRIPTION
We use UUID4's to identify content panels in a way that is unique across windows,
and across reloads. This replaces the existing system of `windowNumber:DijitPaneId`,
which was brittle, and required careful maintenance every time a panel was moved.


RELEASE NOTES

Bug Fixes

* Widget group control mappings across windows used to be able to create an
  inconsistent state after the primary window was reloaded. Now such mappings
  are properly saved and restored.
