### PR TITLE
Bugfix in meson script interpreter

### DIFF
--- a/server/pfsc/excep.py
+++ b/server/pfsc/excep.py
@@ -266,6 +266,7 @@ class PECode:
     MESON_EXCESS_MODAL = 310
     MESON_EMPTY = 311
     MESON_UNKNOWN_TOKEN = 312
+    MESON_BAD_GHOST_NODE = 313
     ARCLANG_ERROR = 350
 
     # writer stuff

--- a/server/pfsc/lang/deductions.py
+++ b/server/pfsc/lang/deductions.py
@@ -586,6 +586,9 @@ class Deduction(Enrichment, NodeLikeObj):
             fn = S.groups()[0]
         return fn
 
+    def canAppearAsGhostInMesonScript(self):
+        return True
+
     def generateGhostName(self):
         gn = self.generateFriendlyName()
         if len(gn) >= 5 and gn[:5] == 'Proof':
@@ -688,7 +691,6 @@ class Deduction(Enrichment, NodeLikeObj):
         # Mark bridge edges.
         graph.findAndMarkBridges()
         graph.markFlowLinkOutsAsBridges()
-
 
     def buildDashgraph(self, lang='en'):
         """
@@ -992,6 +994,9 @@ class Node(NodeLikeObj):
             text += ref.write_pdf_render_div()
 
         return text
+
+    def canAppearAsGhostInMesonScript(self):
+        return True
 
     def generateGhostName(self):
         home = self.getDeduction()

--- a/server/pfsc/lang/meson.py
+++ b/server/pfsc/lang/meson.py
@@ -197,6 +197,9 @@ class Graph:
 
             (N2) A non-modal node never occurs inside a supposition.
 
+            (N3) Only certain types of proofscsape objects (deducs and nodes)
+                can be referenced by a ghost node in a Meson script.
+
         Checks on the endpoints of arrows (edges):
 
             (E1) A deduction arrow may not have a subdeduction or a
@@ -219,7 +222,8 @@ class Graph:
           targets of this deduction.
         """
 
-        # (I) Check supp and intr nodes.
+        # (I) Check nodes.
+        # (N1 and N2) Check supp and intr nodes.
         for node in self.nodes.values():
             node_is_modal = node.actualNode.isModal()
             if (self.src_type == GraphSource.MESON and node_is_modal
@@ -231,6 +235,15 @@ class Graph:
                 msg = 'Only modal nodes may occur after modal keywords'
                 msg += ', but node "%s" breaks this rule.' % node.name
                 raise PfscExcep(msg, PECode.MESON_MODAL_MISMATCH)
+        # (N3) ghost node references
+        for node in self.nodes.values():
+            if node.actualNode.isGhostNode():
+                r = node.actualNode.realObj()
+                if not r.canAppearAsGhostInMesonScript():
+                    msg = (f'Node "{node.name}" of type {r.__class__} cannot'
+                           ' occur in a meson script. Did you mean to reference'
+                           ' something defined within it?')
+                    raise PfscExcep(msg, PECode.MESON_BAD_GHOST_NODE)
 
         # (II) Check edges.
         # Get the list of libpaths of the targets.

--- a/server/pfsc/lang/objects.py
+++ b/server/pfsc/lang/objects.py
@@ -216,6 +216,9 @@ class PfscObj:
     def isGhostNode(self):
         return False
 
+    def canAppearAsGhostInMesonScript(self):
+        return False
+
     def isSubNode(self):
         return False
 

--- a/server/tests/resources/repo/foo/bar/v17/expansions.pfsc
+++ b/server/tests/resources/repo/foo/bar/v17/expansions.pfsc
@@ -1,0 +1,139 @@
+
+from ..results import Pf
+
+########################################################################
+# This time we trigger the error wherein something other than a
+# deduc or a node is named in a meson script.
+
+import ..results as res
+
+deduc foo {
+    asrt C {
+        sy="C"
+    }
+    meson = "
+    From res, get C.
+    "
+}
+
+########################################################################
+
+deduc X of Pf.S {
+
+    asrt A1 {
+        en = "A thing that helps to clarify"
+    }
+
+    asrt A2 {
+        en = "Another thing"
+    }
+
+    meson="
+    Pf.S by A1 and A2 and Pf.R.
+    "
+
+}
+
+anno Notes1 @@@
+Some enlightening notes...
+with a <chart:w10>[chart widget with *cool equation* $@e sup i pie; + 1 = 0$ in the label]{
+    "view": "Pf"
+}
+This time we give it its own name, and even put it in a different pane group.
+Now let's add checkboxes.
+<chart:w20>[]{
+    "view": "X",
+    "group": 2,
+    "checkboxes": {
+        "deducs": "Pf"
+    }
+}
+@@@
+
+anno Notes2 @@@
+And let's also add another annotation. This time, let's have
+<qna:q1>[a widget where]{
+    "question":"one of the strings",
+    "answer":"has an unmatched open brace ({) in it"
+}
+and
+<qna:q2>[another widget where]{
+    "question":"one of the strings",
+    "answer":"has an unmatched close brace (}) in it"
+}
+and while we're at it, let's have
+<qna:q3>[a widget where]{
+    "question":"one of the strings",
+    "answer":"is
+             multiline,
+             and has an escaped quotation mark (\") within it.
+             "
+}
+and just for good measure, let's have
+<qna:q4>[a widget where]{
+    "question":"one of the strings",
+    "answer":"combines
+          several
+               of
+                   these
+               }}}{{{{}{}{ \"\"   {\"  }}} \" {{{{}} }{ {{ \"
+             things.
+             "
+}
+@@@
+
+anno Notes3 @@@
+# Testing goal widget altpaths
+
+<goal:w1>[This is a goal]{
+    altpath: "Notes3.w2"
+}
+
+<goal:w2>[This is another goal]{
+    altpath: "w2"
+}
+
+<goal:w3>[This is yet another goal]{
+}
+@@@
+
+# This time we test our expanded JSON syntax wherein
+# you may use libpaths as long as they resolve within
+# the scope where we're working.
+obj1 = {
+    foo: ["bar", 3, true, false, null]
+}
+
+obj2 = {
+    spam: obj1
+}
+
+anno Notes4 @@@
+This <label:>[widget]{
+    will: "define some extra",
+    stuff: obj2
+}
+@@@
+
+# We also need to test whether we correctly ignore # chars occurring within
+# strings (i.e. do _not_ strip them out as comments).
+# Also in this version I moved some words around in the last two comment lines,
+# so we can test out our Git-style merge conflict function, by comparing v11
+# and v12.
+
+This_is_a_string = "that has a # char and an escaped \" char inside of it."
+Here_is_a_single_quoted_string = 'that has a # char and an escaped \' char.'
+
+anno Notes4 @@@
+
+If the server is configured so that param and disp widgets are not allowed in
+untrusted repos, then this module should fail to load, since `test.foo.bar` is
+untrusted.
+
+<disp:eg1_disp1>[]{
+    build: "
+return 'foo'
+",
+}
+
+@@@

--- a/server/tests/resources/repo/foo/bar/v17/results.pfsc
+++ b/server/tests/resources/repo/foo/bar/v17/results.pfsc
@@ -1,0 +1,65 @@
+
+deduc Thm {
+
+    asrt C {
+        en = "Some amazing theorem statement."
+    }
+
+    meson = "C"
+
+}
+
+deduc Pf of Thm.C {
+
+    asrt R {
+        en = "Something self-evident"
+    }
+
+    asrt S {
+        en = "An easy consequence"
+    }
+
+    meson = "
+    R, so S, therefore Thm.C
+    "
+
+}
+
+deduc Thm2 {
+    supp S {
+        sy="$S$"
+    }
+    asrt A {
+        sy="$A$"
+    }
+    meson="Suppose S. Then A."
+}
+
+
+deduc Pf2 of Thm2.A {
+
+    asrt B {
+        sy="$B$"
+    }
+
+    mthd M wolog {
+        en="
+        Adding an
+        appropriate constant
+        to $f(x)$
+        "
+    }
+
+    asrt C {
+        sy="$C$"
+    }
+
+    # ISSUE @v0.25.0: https://github.com/proofscape/pfsc-server/issues/7
+    # Meson script should not say `by B` (since it is redundant).
+    # If you delete that, it builds just fine.
+    # However, with it, not only does it fail to build, but the build process crashes.
+    meson="
+    From Thm2.S get B.
+    Then C, by B, applying M, hence Thm2.A.
+    "
+}

--- a/server/tests/test_meson.py
+++ b/server/tests/test_meson.py
@@ -423,6 +423,21 @@ def test_issue_7(app):
             assert dg['edges'] == Pf2_edges
 
 
+@pytest.mark.psm
+def test_issue_14(app):
+    """
+    See https://github.com/proofscape/pise/issues/14
+    """
+    with app.app_context():
+        libpath = "test.foo.bar.expansions"
+        version = "v17.0.0"
+        ri = get_repo_info(libpath)
+        with checkout(ri, version):
+            with pytest.raises(PfscExcep) as ei:
+                load_module(libpath)
+            assert ei.value.code() == PECode.MESON_BAD_GHOST_NODE
+
+
 ######################################################################
 # Manual testing
 


### PR DESCRIPTION
Fixes #14 

If user accidentally references anything other than a deduc or a node, in a meson script, we now raise a helpful error message. Before, the build process was simply crashing with an `AttributeError`.

RELEASE NOTES

Bug Fixes

* Stopped build from crashing if a whole module was (accidentally) named in a
  meson script.