### PR TITLE
Tuneup CI

### DIFF
--- a/.github/workflows/pise-build-and-test.yml
+++ b/.github/workflows/pise-build-and-test.yml
@@ -249,9 +249,9 @@ jobs:
           echo "Full Chrome version: $FULL_CHR_VERS"
           TRUNC_CHR_VERS=`echo $FULL_CHR_VERS | sed -e 's#\.[0-9]\+$##'`
           echo "Truncated Chrome version: $TRUNC_CHR_VERS"
-          CHR_DRIVER_VERS=`curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$TRUNC_CHR_VERS`
+          CHR_DRIVER_VERS=`curl https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_$TRUNC_CHR_VERS`
           echo "Chrome driver version: $CHR_DRIVER_VERS"
-          echo "chromedriver-url=https://chromedriver.storage.googleapis.com/$CHR_DRIVER_VERS/chromedriver_linux64.zip" >> $GITHUB_ENV
+          echo "chromedriver-url=https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/$CHR_DRIVER_VERS/linux64/chromedriver-linux64.zip" >> $GITHUB_ENV
       - name: Cache chromedriver
         id: cache-chromedriver
         uses: actions/cache@v3
@@ -262,8 +262,8 @@ jobs:
         name: Install chromedriver
         run: |
           wget ${{ env.chromedriver-url }}
-          unzip chromedriver_linux64.zip
-          mv chromedriver /usr/local/bin/
+          unzip chromedriver-linux64.zip
+          mv chromedriver-linux64/chromedriver /usr/local/bin/
       # -----------------------------------------
       # Make directories with pfsc makestruct
       - name: makestruct

--- a/.github/workflows/pise-build-and-test.yml
+++ b/.github/workflows/pise-build-and-test.yml
@@ -542,7 +542,7 @@ jobs:
           echo "------------------------------"
           grep LICENSES.txt $WDLL
           grep NOTICE.txt $WDLL
-          test `grep LICENSES.txt $WDLL | awk '{print $5}'` -ge 200000
+          test `grep LICENSES.txt $WDLL | awk '{print $5}'` -ge 150000
           test `grep NOTICE.txt $WDLL | awk '{print $5}'` -ge 700
       # If it's basic testing, and we had a cache miss, then it's time to save the image we built.
       - if: ${{!inputs.pub-prep && steps.cache-pise-server.outputs.cache-hit != 'true' }}

--- a/.github/workflows/pise-build-and-test.yml
+++ b/.github/workflows/pise-build-and-test.yml
@@ -148,7 +148,7 @@ jobs:
         run: |
           echo "USE_BASE_NGINX_FRONTEND=1" >> $GITHUB_ENV
           echo "PISE_VERS=testing" >> $GITHUB_ENV
-          echo "DEBUG_WORKFLOW=${{ inputs.debug-level || 1 }}" >> $GITHUB_ENV
+          echo "DEBUG_WORKFLOW=${{ inputs.debug-level || 2 }}" >> $GITHUB_ENV
       - if: ${{ inputs.pub-prep }}
         name: Configure for pub-prep
         run: |

--- a/client/src/Hub.js
+++ b/client/src/Hub.js
@@ -867,6 +867,7 @@ var Hub = declare(null, {
         this.bcastChannel = new BroadcastChannel('login-messages');
         this.bcastChannel.addEventListener('message', event => {
             if (event.data === 'login-successful') {
+                console.debug('updateUser after `login-successful` event');
                 this.updateUser();
             }
         });
@@ -1042,6 +1043,7 @@ var Hub = declare(null, {
             // App has regained focus.
             //console.log('hub focused');
             if (!this.personalServerMode) {
+                console.debug('updateUser after app regained focus');
                 this.updateUser();
             }
             // Mostly we let EditManager decide what to do based on the configured method;
@@ -1069,6 +1071,7 @@ var Hub = declare(null, {
         //console.log('visible: ', isVisible);
         if (isVisible) {
             if (!this.personalServerMode) {
+                console.debug('updateUser after app regained visibility');
                 this.updateUser();
             }
             this.pdfManager.retryPausedDownloads();

--- a/manage/tests/selenium/test_basic_run_mca.py
+++ b/manage/tests/selenium/test_basic_run_mca.py
@@ -38,7 +38,7 @@ class TestBasicRunMCA(Tester):
         time.sleep(1)
         self.dismiss_cookie_notice()
         self.check_user_menu()
-        self.login_as_test_user('hist')
+        self.login_as_test_user('hist', wait=1)
 
         repopath = "test.hist.lit"
 

--- a/manage/tests/selenium/test_basic_run_mca.py
+++ b/manage/tests/selenium/test_basic_run_mca.py
@@ -30,6 +30,12 @@ class TestBasicRunMCA(Tester):
         # https://docs.pytest.org/en/6.2.x/logging.html#caplog-fixture
         caplog.set_level(selenium_logging_level, logger=__name__)
 
+        # Is there any way to set the format of caplog?
+        # The following raises no exceptions, but also has no effect on the printed logs:
+        #formatter = logging.Formatter(fmt='%(asctime)s %(levelname)-8s %(message)s',
+        #                              datefmt='%Y-%m-%d %H:%M:%S')
+        #caplog.handler.setFormatter(formatter)
+
         server_status_code, server_status_message = self.check_pise_server(deployment='mca')
         assert server_status_code == 4
         logger.info(f'PISE server check: {server_status_message}')
@@ -96,3 +102,5 @@ class TestBasicRunMCA(Tester):
         # Wait a second and log out
         time.sleep(1)
         self.log_out()
+
+        self.log_browser_console()

--- a/manage/tests/selenium/test_basic_run_mca.py
+++ b/manage/tests/selenium/test_basic_run_mca.py
@@ -38,7 +38,7 @@ class TestBasicRunMCA(Tester):
         time.sleep(1)
         self.dismiss_cookie_notice()
         self.check_user_menu()
-        self.login_as_test_user('hist', wait=1)
+        self.login_as_test_user('hist')
 
         repopath = "test.hist.lit"
 

--- a/manage/tests/selenium/util.py
+++ b/manage/tests/selenium/util.py
@@ -47,13 +47,15 @@ def make_driver():
     driver = None
     if browser == "CHROME":
         options = ChromeOptions()
-        options.headless = headless
+        if headless:
+            options.add_argument('--headless')
         if pfsc_conf.SEL_STAY_OPEN:
             options.add_experimental_option("detach", True)
         return webdriver.Chrome(options=options)
     elif browser == "FIREFOX":
         options = FirefoxOptions()
-        options.headless = headless
+        if headless:
+            options.add_argument('--headless')
         return webdriver.Firefox(options=options)
 
     return driver

--- a/manage/tests/selenium/util.py
+++ b/manage/tests/selenium/util.py
@@ -195,9 +195,60 @@ def login_as_test_user(driver, user, wait=BASIC_WAIT, logger_name='root'):
     driver.find_element(By.NAME, "password").send_keys(user)
     logger.debug(ts("Before log-in click"))
     driver.find_element(By.CSS_SELECTOR, "p > input").click()
+
+    # Before we close the login window, pause to allow time for the login to
+    # take place. The following things need to happen: (1) the server receives
+    # the login request; (2) the server sends back a 302 redirecting us to the
+    # login-success page; (3) we request the login-success page; (4) some JS
+    # on the login-success page emits a login-success event over BroadcastChannel.
+    # After that, it is okay to close the login window. The main window will
+    # hear the login-success event, which is what prompts it to issue a `whoAmI`
+    # request to the server, to find out which user it is now logged in as, and
+    # then it updates the User menu accordingly.
+    #
+    # Probably half a second would be plenty of time, but we err on the generous
+    # side, giving it 3 seconds.
+    #
+    # On 230826, we started having intermittent failures (maybe one in five runs
+    # or so), where it seems we were closing the login window too quickly. At that
+    # time, we actually had no delay here whatsoever before closing the window.
+    #
+    # The web server logs showed that we were
+    # getting the 302 redirect (so, successful login) and we requested the
+    # login-success page, but we never made the `whoAmI` request. This suggests
+    # that we were closing the login window before it had a chance to emit the
+    # login-success event over BroadcastChannel. Note that that event's triggering
+    # of `Hub.updateUser()` is necessary here, because there will be no `focus` event
+    # on the main window (which also would trigger `Hub.updateUser()`) during headless
+    # execution of Chrome via Chromedriver.
+    logger.debug(ts("After log-in click"))
+    time.sleep(3)
     driver.close()
+    logger.debug(ts("After close log-in window"))
     driver.switch_to.window(v["root"])
+
     # User menu text should now say our username
+    # Instead of just relying on `WebDriverWait()` to do the waiting for us,
+    # we give the menu one second to update, and, if it fails to do so, we
+    # err out but only after logging the browser console. This is so we can look
+    # for debug messages there, issued by the `Hub` when it checks the user login
+    # state.
+    t0 = time.time()
+    for i in range(101):
+        t1 = time.time()
+        dt = t1 - t0
+        menu_label = driver.find_element(by=By.ID, value="dijit_PopupMenuBarItem_8_text").text
+        logger.debug(f'Menu label at {int(1000*dt)}ms: {menu_label}')
+        # If it has already changed, no sense continuing to log.
+        if menu_label == f"test.{user}":
+            break
+        # If it takes 1s or more, fail after logging browser console.
+        if dt >= 1:
+            logger.debug('Menu label took 1s or more to change!')
+            log_browser_console(driver, logger_name=logger_name)
+            assert False
+        time.sleep(0.01)
+
     WebDriverWait(driver, wait).until(expected_conditions.text_to_be_present_in_element((By.ID, "dijit_PopupMenuBarItem_8_text"), f"test.{user}"))
     assert driver.find_element(By.ID, "dijit_PopupMenuBarItem_8_text").text == f"test.{user}"
     logger.info(f"Logged in as test.{user}")

--- a/server/tests/test_manifest.py
+++ b/server/tests/test_manifest.py
@@ -376,7 +376,7 @@ def test_doc_info(repos_ready):
         "pdffp:73a76954e6a0db76a97e98bdac835811",
         "pdffp:f55073bb58f8823ebfa19482ab6fdabe"
     ]
-    assert list(d["doc_info"].keys()) == doc_ids
+    assert set(d["doc_info"].keys()) == set(doc_ids)
 
     Thm9 = manifest.lookup["test.hist.lit.H.ilbert.ZB.Thm9.Pf"]
     assert len(Thm9.build_dict()["docRefs"][doc_ids[1]]) == 4
@@ -393,7 +393,7 @@ def test_doc_info(repos_ready):
     doc_ids = [
         "pdffp:6318d851c27fc30fd97ac614cf747ac0"
     ]
-    assert list(d["doc_info"].keys()) == doc_ids
+    assert set(d["doc_info"].keys()) == set(doc_ids)
 
     wt = manifest.lookup["test.comment.notes.H.ilbert.ZB.Thm168.notes.Walkthrough"]
     assert len(wt.build_dict()["docRefs"][doc_ids[0]]) == 1


### PR DESCRIPTION
Misc updates to CI tests to deal with recent bit rot

* There is a new download process for `chromedriver`, from `v115` onward
* A unit test that still passes on my machine and depends on order of keys in a dict fails on the GH testrunner; now making the order unimportant.
* Size check on a license file is made more lenient (for upcoming changes)
* Responded to a deprecation in Selenium
* Added a delay for the login process in Selenium tests, to prevent a new timeout failure we started getting as of 230826