### PR TITLE
Repair static dir in OCA image

### DIFF
--- a/manage/tools/deploy/services.py
+++ b/manage/tools/deploy/services.py
@@ -326,8 +326,8 @@ def proofscape_oca(deploy_dir_path, tag='latest', mount_code=False, mount_pkg=No
     versions = get_version_numbers()
     if mount_code:
         d['volumes'].append(f'{resolve_pfsc_root_subdir("src/pfsc-server/pfsc")}:/home/pfsc/proofscape/src/pfsc-server/pfsc:ro')
-        d['volumes'].append(f'{resolve_pfsc_root_subdir("src/pfsc-server/static/css")}:/home/pfsc/proofscape/src/pfsc-server/static/v{pfsc_server_vers}/css:ro')
-        d['volumes'].append(f'{resolve_pfsc_root_subdir("src/pfsc-server/static/img")}:/home/pfsc/proofscape/src/pfsc-server/static/v{pfsc_server_vers}/img:ro')
+        d['volumes'].append(f'{resolve_pfsc_root_subdir("src/pfsc-server/static/css")}:/home/pfsc/proofscape/src/pfsc-server/static/css:ro')
+        d['volumes'].append(f'{resolve_pfsc_root_subdir("src/pfsc-server/static/img")}:/home/pfsc/proofscape/src/pfsc-server/static/img:ro')
         d['volumes'].append(f'{resolve_pfsc_root_subdir("src/pfsc-server/config.py")}:/home/pfsc/proofscape/src/pfsc-server/config.py:ro')
         d['volumes'].append(f'{resolve_pfsc_root_subdir("src/pfsc-ise/package.json")}:/home/pfsc/proofscape/src/client/package.json:ro')
         d['volumes'].append(f'{resolve_pfsc_root_subdir("src/pfsc-server/web.py")}:/home/pfsc/proofscape/src/pfsc-server/web.py:ro')

--- a/manage/topics/pfsc/templates/Dockerfile.oca_static
+++ b/manage/topics/pfsc/templates/Dockerfile.oca_static
@@ -17,9 +17,6 @@
 WORKDIR /home/pfsc/proofscape/src/pfsc-server/static
 RUN ln -s /proofscape/PDFLibrary \
  && mkdir -p pyodide/v{{versions["pyodide"]}} \
- && mkdir v{{server_vers}} \
- && mv css v{{server_vers}}/ \
- && mv img v{{server_vers}}/ \
  && bash -c "mkdir -p {whl,ise,dojo,mathjax,elk}"
 
 {% for filename in pyodide_files %}


### PR DESCRIPTION
The built-in `css` and `img` dirs in `pise/server` were being incorrectly put under a version dir. The URL has a version number in it, for cache busting, but, internally, Flask routes these requests to a filesystem path that does not include the version segment.

Due to the incorrect placement, our 404 page was failing to find the img and css it needed.