### PR TITLE
Upgrade supporting packages

### DIFF
--- a/client/other-versions.json
+++ b/client/other-versions.json
@@ -1,13 +1,13 @@
 {
   "pfsc-pdf": "3.2.0",
   "pyodide": "0.21.0",
-  "pfsc-examp": "0.23.0b0",
+  "pfsc-examp": "0.23.0",
   "pfsc-util": "0.22.8",
   "displaylang": "0.23.0",
   "displaylang-sympy": "0.10.4",
   "lark": "0.6.7",
   "typeguard": "2.13.3",
   "mpmath": "1.2.1",
-  "Jinja2": "3.0.3",
-  "MarkupSafe": "2.0.1"
+  "Jinja2": "3.1.2",
+  "MarkupSafe": "2.1.1"
 }

--- a/server/req/dev-requirements.in
+++ b/server/req/dev-requirements.in
@@ -6,5 +6,5 @@
 -c requirements.txt
 -c test-requirements.txt
 
-pip-tools==6.6.2
+pip-tools==7.3.0
 rq-dashboard==0.6.1

--- a/server/req/dev-requirements.txt
+++ b/server/req/dev-requirements.txt
@@ -14,6 +14,10 @@ blinker==1.6.2 \
     # via
     #   -c requirements.txt
     #   flask
+build==0.10.0 \
+    --hash=sha256:af266720050a66c893a6096a2f410989eeac74ff9a68ba194b3f6473e8e26171 \
+    --hash=sha256:d5b71264afdb5951d6704482aac78de887c80691c52b88a9ad195983ca2c9269
+    # via pip-tools
 click==8.1.3 \
     --hash=sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e \
     --hash=sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48
@@ -93,14 +97,26 @@ markupsafe==2.1.1 \
     #   -c test-requirements.txt
     #   jinja2
     #   werkzeug
-pep517==0.12.0 \
-    --hash=sha256:931378d93d11b298cf511dd634cf5ea4cb249a28ef84160b3247ee9afb4e8ab0 \
-    --hash=sha256:dd884c326898e2c6e11f9e0b64940606a93eb10ea022a2e067959f3a110cf161
-    # via pip-tools
-pip-tools==6.6.2 \
-    --hash=sha256:6b486548e5a139e30e4c4a225b3b7c2d46942a9f6d1a91143c21b1de4d02fd9b \
-    --hash=sha256:f638503a9f77d98d9a7d72584b1508d3f82ed019b8fab24f4e5ad078c1b8c95e
+packaging==21.3 \
+    --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
+    --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
+    # via
+    #   -c test-requirements.txt
+    #   build
+pip-tools==7.3.0 \
+    --hash=sha256:8717693288720a8c6ebd07149c93ab0be1fced0b5191df9e9decd3263e20d85e \
+    --hash=sha256:8e9c99127fe024c025b46a0b2d15c7bd47f18f33226cf7330d35493663fc1d1d
     # via -r dev-requirements.in
+pyparsing==3.0.9 \
+    --hash=sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb \
+    --hash=sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc
+    # via
+    #   -c test-requirements.txt
+    #   packaging
+pyproject-hooks==1.0.0 \
+    --hash=sha256:283c11acd6b928d2f6a7c73fa0d01cb2bdc5f07c57a2eeb6e83d5e56b97976f8 \
+    --hash=sha256:f271b298b97f5955d53fb12b72c1fb1948c22c1a6b70b315c54cedaca0264ef5
+    # via build
 python-dateutil==2.8.2 \
     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
     --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
@@ -132,7 +148,9 @@ tomli==2.0.1 \
     --hash=sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f
     # via
     #   -c test-requirements.txt
-    #   pep517
+    #   build
+    #   pip-tools
+    #   pyproject-hooks
 werkzeug==2.3.7 \
     --hash=sha256:2b8c0e447b4b9dbcc85dd97b6eeb4dcbaf6c8b6c3be0bd654e25553e0a2157d8 \
     --hash=sha256:effc12dba7f3bd72e605ce49807bbe692bd729c3bb122a3b91747a6ae77df528
@@ -151,6 +169,7 @@ zipp==3.8.0 \
     #   importlib-metadata
 
 # WARNING: The following packages were not pinned, but pip requires them to be
-# pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.
+# pinned when the requirements file includes hashes and the requirement is not
+# satisfied by a package already installed. Consider using the --allow-unsafe flag.
 # pip
 # setuptools

--- a/server/req/test-requirements.hashless
+++ b/server/req/test-requirements.hashless
@@ -7,4 +7,4 @@
 #-e ../displaylang
 #-e ../sympy
 
-git+https://github.com/proofscape/pfsc-test-modules.git@v0.27.0b1
+git+https://github.com/proofscape/pfsc-test-modules.git@v0.27.0

--- a/server/req/test-requirements.in
+++ b/server/req/test-requirements.in
@@ -12,4 +12,4 @@ pytest-cov==4.0.0
 # is instead delivered to the user's browser via Pyodide) we do have unit
 # tests here in pfsc-server that help test code living in the pfsc-examp
 # project. So for testing we do install it.
-pfsc-examp==0.23.0b0
+pfsc-examp==0.23.0

--- a/server/req/test-requirements.txt
+++ b/server/req/test-requirements.txt
@@ -134,9 +134,9 @@ packaging==21.3 \
     --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
     --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
     # via pytest
-pfsc-examp==0.23.0b0 \
-    --hash=sha256:418dad0543d44dd8d4890c5a809ac01885df48c4d11d3c425fc2bf74a92c7ede \
-    --hash=sha256:62a843daae149de16ca66db7c16755198f744ea4e2d95481eb86fde7924b1c66
+pfsc-examp==0.23.0 \
+    --hash=sha256:1ab6bbfb06e24f27204ed90b3128a592dc203857161f5c3863d562c95b2342f8 \
+    --hash=sha256:a5cbd531f0690111c16739063aaf1b04b2c6b30c9a95cb56f4b4d7b6a6254786
     # via -r test-requirements.in
 pfsc-util==0.22.8 \
     --hash=sha256:2967e36233fc05b303257d1639317e9d8db3e50f8054cc5f48b8da6dd36042a0 \


### PR DESCRIPTION
* `pfsc-examp` & `pfsc-test-modules`: move to full release, instead of beta
* Upgrade `pip-tools` -- we were getting a stacktrace while running our `compile.sh` script
* Update `other-versions.json` to match versions included with pyodide