### PR TITLE
Move `ise/util` from AMD to ES6

### DIFF
--- a/client/src/Hub.js
+++ b/client/src/Hub.js
@@ -18,20 +18,19 @@ import { xhr, enrichXhrParams } from "browser-peers/src/util";
 import { DedicatedWorkerPeer } from "browser-peers/src/dedworkerpeer";
 import { ContentLoadTask } from "./delayed";
 const otherVersions = require('../other-versions.json');
+import { util as iseUtil } from "./util";
 
 
 define([
     "dojo/_base/declare",
     "dojo/query",
     "dijit/Dialog",
-    "dijit/ConfirmDialog",
-    "ise/util"
+    "dijit/ConfirmDialog"
 ], function(
     declare,
     query,
     Dialog,
-    ConfirmDialog,
-    iseUtil
+    ConfirmDialog
 ){
 
 /* The Hub class provides a central connection point, where the various

--- a/client/src/content_types/SubscriptionManager.js
+++ b/client/src/content_types/SubscriptionManager.js
@@ -14,15 +14,7 @@
  *  limitations under the License.                                           *
  * ------------------------------------------------------------------------- */
 
-const dojo = {};
-
-define([
-    "ise/util",
-], function(
-    iseUtil,
-) {
-    dojo.iseUtil = iseUtil;
-});
+import { util as iseUtil } from "../util";
 
 /* Helper for content type managers (like ChartManager and NotesManager) that host
  * content that can be rebuilt (and for which a "subscription" is therefore needed).
@@ -52,8 +44,8 @@ export class SubscriptionManager {
         this.missingObjHandler = missingObjHandler;
         this.reloader = reloader;
 
-        this.libpathsToSubscribedPaneIds = new dojo.iseUtil.LibpathSetMapping();
-        this.modpathsToLibpathsHavingSubscribers = new dojo.iseUtil.LibpathSetMapping();
+        this.libpathsToSubscribedPaneIds = new iseUtil.LibpathSetMapping();
+        this.modpathsToLibpathsHavingSubscribers = new iseUtil.LibpathSetMapping();
 
         this.hub.socketManager.on('repoBuilt', this.handleRepoBuiltEvent.bind(this));
     }
@@ -65,7 +57,7 @@ export class SubscriptionManager {
      * param doSubscripe: boolean true to subscribe, false to unsubscribe
      */
     setSubscription(paneId, libpath, doSubscribe) {
-        const modpath = dojo.iseUtil.getModpathFromTopLevelEntityPath(libpath);
+        const modpath = iseUtil.getModpathFromTopLevelEntityPath(libpath);
         if (doSubscribe) {
             this.libpathsToSubscribedPaneIds.add(libpath, paneId);
             this.modpathsToLibpathsHavingSubscribers.add(modpath, libpath);
@@ -86,7 +78,7 @@ export class SubscriptionManager {
     /* Unsubscribe all panes from a given libpath.
      */
     removeAllSubscriptionsForLibpath(libpath) {
-        const modpath = dojo.iseUtil.getModpathFromTopLevelEntityPath(libpath);
+        const modpath = iseUtil.getModpathFromTopLevelEntityPath(libpath);
         this.libpathsToSubscribedPaneIds.mapping.delete(libpath);
         this.modpathsToLibpathsHavingSubscribers.remove(modpath, libpath);
     }

--- a/client/src/content_types/chart/ChartManager.js
+++ b/client/src/content_types/chart/ChartManager.js
@@ -21,7 +21,6 @@ const moose = {
     head: head,
     Forest: Forest
 };
-
 import { MooseNodeLabelPlugin } from "../../plugins/MooseNodeLabelPlugin";
 import { NoGroupError } from "browser-peers/src/errors";
 import { GlobalLinkingMap } from "../linking";
@@ -32,14 +31,12 @@ define([
     "dojo/_base/lang",
     "ise/content_types/AbstractContentManager",
     "ise/plugins/MooseContextMenuPlugin",
-    "ise/util",
     "ise/errors"
 ], function(
     declare,
     lang,
     AbstractContentManager,
     MooseContextMenuPlugin,
-    iseUtil,
     iseErrors
 ) {
 

--- a/client/src/content_types/chart/TheorymapManager.js
+++ b/client/src/content_types/chart/TheorymapManager.js
@@ -105,8 +105,8 @@ var TheorymapManager = declare(ChartManager, {
      * param serialOnly: boolean; set true if you want only serializable info.
      * return: The info object.
      */
-    writeStateInfo: function(oldPaneId, serialOnly) {
-        var state = this.inherited(arguments);
+    writeStateInfo: function writeStateInfo(oldPaneId, serialOnly) {
+        var state = this.inherited(writeStateInfo, arguments);
         state.theorymap = this.mapDescripsByPaneId[oldPaneId];
         state.type = this.hub.contentManager.crType.THEORYMAP;
         return state;
@@ -117,8 +117,8 @@ var TheorymapManager = declare(ChartManager, {
      * param closingPane: The ContentPane that is about to close.
      * return: nothing
      */
-    noteClosingContent: function(closingPane) {
-        this.inherited(arguments);
+    noteClosingContent: function noteClosingContent(closingPane) {
+        this.inherited(noteClosingContent, arguments);
         delete this.mapDescripsByPaneId[closingPane.id];
     },
 

--- a/client/src/content_types/notes/AnnoViewer.js
+++ b/client/src/content_types/notes/AnnoViewer.js
@@ -16,19 +16,16 @@
 
 import { BasePageViewer } from "./BasePageViewer";
 import { Sidebar } from "./Sidebar";
+import { util as iseUtil } from "../../util";
 
 const dojo = {};
-const ise = {};
 
 define([
-    "dojo/query",
-    "ise/util",
+    "dojo/query"
 ], function(
-    query,
-    util
+    query
 ) {
     dojo.query = query;
-    ise.util = util;
 });
 
 
@@ -150,7 +147,7 @@ export class AnnoViewer extends BasePageViewer {
     setPageContents(html, data) {
         const elt = this.contentElement;
         dojo.query(elt).innerHTML(html);
-        ise.util.typeset([elt]);
+        iseUtil.typeset([elt]);
         this.currentPageData = data;
         this.nm.setupWidgets(data, this.elt, this.pane);
     }
@@ -224,7 +221,7 @@ export class AnnoViewer extends BasePageViewer {
 
     getCurrentLibpathv() {
         const loc = this.getCurrentLoc();
-        return loc === null ? null : ise.util.lv(loc.libpath, loc.version);
+        return loc === null ? null : iseUtil.lv(loc.libpath, loc.version);
     }
 
     setTheme(theme) {

--- a/client/src/content_types/notes/BasePageViewer.js
+++ b/client/src/content_types/notes/BasePageViewer.js
@@ -15,22 +15,19 @@
  * ------------------------------------------------------------------------- */
 
 import { Listenable } from "browser-peers/src/util";
+import { util as iseUtil } from "../../util";
 
-const ise = {};
 const dojo = {};
 
 define([
     "dijit/Menu",
-    "dijit/MenuItem",
-    "ise/util",
+    "dijit/MenuItem"
 ], function(
     Menu,
-    MenuItem,
-    util
+    MenuItem
 ) {
     dojo.Menu = Menu;
     dojo.MenuItem = MenuItem;
-    ise.util = util;
 });
 
 export class BasePageViewer extends Listenable {
@@ -104,7 +101,7 @@ export class BasePageViewer extends Listenable {
     }
 
     typeset(elements, win) {
-        return ise.util.typeset(elements, win);
+        return iseUtil.typeset(elements, win);
     }
 
     setupBackgroundClickHandler() {
@@ -472,7 +469,7 @@ export class BasePageViewer extends Listenable {
 
         this.addScrollPadding(options);
 
-        ise.util.scrollIntoView(elt, display, options);
+        iseUtil.scrollIntoView(elt, display, options);
         return true;
     }
 

--- a/client/src/content_types/notes/NotesManager.js
+++ b/client/src/content_types/notes/NotesManager.js
@@ -18,6 +18,7 @@ import { GlobalLinkingMap } from "../linking";
 import { DynamicSubscriptionManager, StaticSubscriptionManager } from "../SubscriptionManager";
 import { AnnoViewer } from "./AnnoViewer";
 import { SphinxViewer } from "./SphinxViewer";
+import { util as iseUtil } from "../../util";
 
 define([
     "dojo/_base/declare",
@@ -32,7 +33,6 @@ define([
     "ise/widgets/PdfWidget",
     "ise/widgets/ParamWidget",
     "ise/widgets/DispWidget",
-    "ise/util",
     "ise/errors",
     "dojo/NodeList-dom",
     "dojo/NodeList-manipulate",
@@ -50,7 +50,6 @@ define([
     PdfWidget,
     ParamWidget,
     DispWidget,
-    iseUtil,
     iseErrors
 ) {
 

--- a/client/src/content_types/notes/Sidebar.js
+++ b/client/src/content_types/notes/Sidebar.js
@@ -14,24 +14,22 @@
  *  limitations under the License.                                           *
  * ------------------------------------------------------------------------- */
 
+import { util as iseUtil } from "../../util";
+
 const dojo = {};
-const ise = {};
 
 define([
     "dijit/Menu",
     "dijit/MenuItem",
-    "dijit/PopupMenuItem",
-    "ise/util",
+    "dijit/PopupMenuItem"
 ], function(
     Menu,
     MenuItem,
-    PopupMenuItem,
-    util
+    PopupMenuItem
 ) {
     dojo.Menu = Menu;
     dojo.MenuItem = MenuItem;
     dojo.PopupMenuItem = PopupMenuItem;
-    ise.util = util;
 });
 
 export class Sidebar {
@@ -64,7 +62,7 @@ export class Sidebar {
         const clone = this.viewedElt.cloneNode(doCloneChildren);
         clone.classList.add('sidebarContents');
         clone.style.transform = `scale(${this.scale/100})`;
-        ise.util.removeAllChildNodes(this.displayElt);
+        iseUtil.removeAllChildNodes(this.displayElt);
         this.displayElt.appendChild(clone);
 
         const glass = this.makeOverviewGlass();

--- a/client/src/content_types/pdf/PdfController.js
+++ b/client/src/content_types/pdf/PdfController.js
@@ -41,6 +41,7 @@
 
 import { LackingHostPermissionError } from "browser-peers/src/errors";
 import { Highlight, PageOfHighlights } from "../venn";
+import { util as iseUtil } from "../../util";
 
 define([
     "dojo/_base/declare",
@@ -48,7 +49,6 @@ define([
     "dijit/Dialog",
     "dijit/layout/ContentPane",
     "ise/content_types/pdf/pdf_util",
-    "ise/util",
     "ise/errors"
 ], function(
     declare,
@@ -56,7 +56,6 @@ define([
     Dialog,
     ContentPane,
     pdf_util,
-    iseUtil,
     pfscErrors
 ) {
 

--- a/client/src/content_types/pdf/PdfManager.js
+++ b/client/src/content_types/pdf/PdfManager.js
@@ -24,6 +24,7 @@ import {
 import {
     GlobalLinkingMap,
 } from "../linking";
+import { util as iseUtil } from "../../util";
 
 define([
     "dojo/_base/declare",
@@ -31,7 +32,6 @@ define([
     "dijit/Dialog",
     "ise/content_types/AbstractContentManager",
     "ise/content_types/pdf/PdfController",
-    "ise/util",
     "ise/errors"
 ], function(
     declare,
@@ -39,7 +39,6 @@ define([
     Dialog,
     AbstractContentManager,
     PdfController,
-    iseUtil,
     pfscErrors
 ) {
 

--- a/client/src/content_types/source/EditManager.js
+++ b/client/src/content_types/source/EditManager.js
@@ -24,6 +24,7 @@ require("ace-builds/src-noconflict/theme-tomorrow_night_eighties.js");
 require("ace-builds/src-noconflict/ext-searchbox.js");
 
 import { SrcViewManager } from "./SrcViewManager";
+import { util as iseUtil } from "../../util";
 
 define([
     "dojo/_base/declare",
@@ -34,7 +35,6 @@ define([
     "dijit/MenuSeparator",
     "dijit/ConfirmDialog",
     "ise/content_types/AbstractContentManager",
-    "ise/util",
     "dojo/NodeList-dom",
     "dojo/NodeList-manipulate",
     "dojo/NodeList-traverse",
@@ -46,8 +46,7 @@ define([
     PopupMenuItem,
     MenuSeparator,
     ConfirmDialog,
-    AbstractContentManager,
-    iseUtil
+    AbstractContentManager
 ) {
 
 // EditManager class

--- a/client/src/content_types/source/SrcViewManager.js
+++ b/client/src/content_types/source/SrcViewManager.js
@@ -14,23 +14,21 @@
  *  limitations under the License.                                           *
  * ------------------------------------------------------------------------- */
 
+import { util as iseUtil } from "../../util";
+
 const dojo = {};
-const ise = {};
 define([
     "dijit/Menu",
     "dijit/MenuItem",
-    "dijit/MenuSeparator",
-    "ise/util"
+    "dijit/MenuSeparator"
 ], function(
     Menu,
     MenuItem,
-    MenuSeparator,
-    util
+    MenuSeparator
 ){
     dojo.Menu = Menu;
     dojo.MenuItem = MenuItem;
     dojo.MenuSeparator = MenuSeparator;
-    ise.util = util;
 });
 
 export class SrcViewManager {
@@ -68,7 +66,7 @@ export class SrcViewManager {
     setContent(editor, modpath, version, paneId, text, fvr, cpos) {
         editor.setValue(text);
         editor.clearSelection();
-        const vmp = ise.util.lv(modpath, version);
+        const vmp = iseUtil.lv(modpath, version);
         this.vmpsByPaneId.set(paneId, vmp);
 
         const oed = editor.pfscIseOverviewEditor;
@@ -94,7 +92,7 @@ export class SrcViewManager {
     getExistingPaneIds(info) {
         const modpath = info.modpath;
         const version = info.version;
-        const vmp0 = ise.util.lv(modpath, version);
+        const vmp0 = iseUtil.lv(modpath, version);
         const ids = [];
         for (let [id, vmp] of this.vmpsByPaneId) {
             if (vmp === vmp0) {

--- a/client/src/content_types/venn.js
+++ b/client/src/content_types/venn.js
@@ -16,22 +16,20 @@
 
 const dojo = {};
 const ise = {};
+import { util as iseUtil } from "../util";
 
 define([
     "dijit/Menu",
     "dijit/MenuItem",
-    "ise/content_types/pdf/pdf_util",
-    "ise/util"
+    "ise/content_types/pdf/pdf_util"
 ], function(
     Menu,
     MenuItem,
-    pdf_util,
-    iseUtil
+    pdf_util
 ) {
     dojo.Menu = Menu;
     dojo.MenuItem = MenuItem;
     ise.pdf_util = pdf_util;
-    ise.util = iseUtil;
 });
 
 /* This module solves the problem of multiple, intersecting highlights on a
@@ -71,7 +69,7 @@ export class Highlight {
     constructor(documentController, highlightDescriptor) {
         this.documentController = documentController;
         this.highlightDescriptorsBySlp = new Map();
-        this.highlightId = ise.util.extractOriginalHlidFromHlDescriptor(highlightDescriptor);
+        this.highlightId = iseUtil.extractOriginalHlidFromHlDescriptor(highlightDescriptor);
         this.depthsByPageNum = new Map();
         this.selectionBoxesByPageNum = new Map();
         this.refinedRegionsByPageNum = new Map();
@@ -289,7 +287,7 @@ export class Highlight {
             const hl = this;
             for (const hdo of this.highlightDescriptorsBySlp.values()) {
                 (hdo => {
-                    const hlid = ise.util.extractHlidFromHlDescriptor(hdo);
+                    const hlid = iseUtil.extractHlidFromHlDescriptor(hdo);
                     menu.addChild(new dojo.MenuItem({
                         // TODO: improve label
                         //  Should be human readable description

--- a/client/src/examp/Chooser.js
+++ b/client/src/examp/Chooser.js
@@ -14,14 +14,14 @@
  *  limitations under the License.                                           *
  * ------------------------------------------------------------------------- */
 
+import { util as iseUtil } from "../util";
+
 define([
     "dojo/_base/declare",
-    "dojo/query",
-    "ise/util",
+    "dojo/query"
 ], function(
     declare,
-    query,
-    iseUtil
+    query
 ) {
 
 /* Chooser base class

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -18,6 +18,7 @@ import { ExtensionClient } from "browser-peers/src/ext";
 import { SocketManager } from "./mgr/SocketManager";
 import { WindowManager } from "./mgr/WindowManager";
 import { RepoManager } from "./trees/RepoManager";
+import { util as iseUtil } from "./util";
 
 require("pfsc-moose/src/css/moose.css")
 
@@ -38,7 +39,6 @@ define([
     "ise/content_types/chart/TheorymapManager",
     "ise/KeyListener",
     "ise/Hub",
-    "ise/util",
     "css!dijit/themes/claro/claro.css",
     "css!dojox/layout/resources/ExpandoPane.css",
     "css!dragula/dist/dragula.css",
@@ -61,8 +61,7 @@ define([
     StudyManager,
     TheorymapManager,
     KeyListener,
-    Hub,
-    iseUtil
+    Hub
 ) {
 
 async function loadScripts() {

--- a/client/src/mgr/ContentManager.js
+++ b/client/src/mgr/ContentManager.js
@@ -18,6 +18,7 @@
 // in the ContentPanes in the Proofscape ISE app.
 
 import { v4 as uuid4 } from 'uuid';
+import { util as iseUtil } from "../util";
 
 define([
     "dojo/_base/declare",
@@ -29,7 +30,6 @@ define([
     "dijit/PopupMenuItem",
     "dijit/MenuSeparator",
     "dijit/layout/ContentPane",
-    "ise/util",
     "dojo/NodeList-dom",
     "dojo/NodeList-manipulate"
 ], function(
@@ -41,8 +41,7 @@ define([
     MenuItem,
     PopupMenuItem,
     MenuSeparator,
-    ContentPane,
-    iseUtil
+    ContentPane
 ) {
 
 // ContentManager class

--- a/client/src/mgr/MenuManager.js
+++ b/client/src/mgr/MenuManager.js
@@ -16,6 +16,7 @@
 
 import { softwareTableRows } from "../piseAboutDialogContents";
 const makeSoftwareTableRow = require('../dialog');
+import { util as iseUtil } from "../util";
 
 define([
     "dojo/_base/declare",
@@ -32,7 +33,6 @@ define([
     "dijit/DropDownMenu",
     "dijit/MenuSeparator",
     "dijit/ConfirmDialog",
-    "ise/util",
     "ise/errors"
 ], function(
     declare,
@@ -49,7 +49,6 @@ define([
     DropDownMenu,
     MenuSeparator,
     ConfirmDialog,
-    iseUtil,
     pfscErrors
 ){
 

--- a/client/src/mgr/StudyManager.js
+++ b/client/src/mgr/StudyManager.js
@@ -14,6 +14,8 @@
  *  limitations under the License.                                           *
  * ------------------------------------------------------------------------- */
 
+import { util as iseUtil } from "../util";
+
 define([
     "dojo/_base/declare",
     "dojo/on",
@@ -23,8 +25,7 @@ define([
     "dijit/layout/TabContainer",
     "dijit/Menu",
     "dijit/MenuItem",
-    "dijit/PopupMenuItem",
-    "ise/util"
+    "dijit/PopupMenuItem"
 ], function(
     declare,
     dojoOn,
@@ -34,8 +35,7 @@ define([
     TabContainer,
     Menu,
     MenuItem,
-    PopupMenuItem,
-    iseUtil
+    PopupMenuItem
 ) {
 
 const StudyManager = declare(null, {

--- a/client/src/plugins/MooseContextMenuPlugin.js
+++ b/client/src/plugins/MooseContextMenuPlugin.js
@@ -14,6 +14,8 @@
  *  limitations under the License.                                           *
  * ------------------------------------------------------------------------- */
 
+import { util as iseUtil } from "../util";
+
 define([
     "dojo/_base/declare",
     "dijit/layout/ContentPane",
@@ -21,8 +23,7 @@ define([
     "dijit/MenuItem",
     "dijit/CheckedMenuItem",
     "dijit/PopupMenuItem",
-    "dijit/MenuSeparator",
-    "ise/util"
+    "dijit/MenuSeparator"
 ], function(
     declare,
     ContentPane,
@@ -30,8 +31,7 @@ define([
     MenuItem,
     CheckedMenuItem,
     PopupMenuItem,
-    MenuSeparator,
-    iseUtil
+    MenuSeparator
 ){
 
 /* This class implements the necessary interface to serve as a

--- a/client/src/plugins/PdfLabelRenderer.js
+++ b/client/src/plugins/PdfLabelRenderer.js
@@ -14,16 +14,15 @@
  *  limitations under the License.                                           *
  * ------------------------------------------------------------------------- */
 
+import { util as iseUtil } from "../util";
+
 const ise = {};
 define([
-    "ise/content_types/pdf/pdf_util",
-    "ise/util"
+    "ise/content_types/pdf/pdf_util"
 ], function(
-    pdf_util,
-    util
+    pdf_util
 ){
     ise.pdf_util = pdf_util;
-    ise.util = util;
 });
 
 /* This class supports the MooseNodeLabelPlugin by providing the tools
@@ -228,7 +227,7 @@ export class PdfLabelRenderer {
                 const divs = codes2divs.get(code);
                 for (let div of divs) {
                     // Clear any prior contents.
-                    ise.util.removeAllChildNodes(div);
+                    iseUtil.removeAllChildNodes(div);
                     if (missing) {
                         div.innerHTML = learnMoreHtml;
                         const lm = div.querySelector('.pdfLearnMore');

--- a/client/src/trees/BuildTreeManager.js
+++ b/client/src/trees/BuildTreeManager.js
@@ -16,8 +16,8 @@
 
 import { TreeManager } from "./TreeManager";
 import { dragulaWithContentPanelOverlays } from "../content_types/dnd";
+import { util as iseUtil } from "../util";
 
-const ise = {};
 const dojo = {};
 
 define([
@@ -27,7 +27,6 @@ define([
     "dijit/MenuItem",
     "dijit/PopupMenuItem",
     "dijit/layout/ContentPane",
-    "ise/util",
     "dojo/NodeList-traverse",
     "dojo/NodeList-manipulate",
 ], function(
@@ -36,8 +35,7 @@ define([
     MenuSeparator,
     MenuItem,
     PopupMenuItem,
-    ContentPane,
-    iseUtil,
+    ContentPane
 ) {
     dojo.query = query;
     dojo.domConstruct = domConstruct;
@@ -45,7 +43,6 @@ define([
     dojo.MenuItem = MenuItem;
     dojo.PopupMenuItem = PopupMenuItem;
     dojo.ContentPane = ContentPane;
-    ise.util = iseUtil;
 });
 
 // We make use of these in managing drag-and-drop:
@@ -149,7 +146,7 @@ export class BuildTreeManager extends TreeManager {
      *   by `ManifestTreeNode.build_relational_model` in `build.py` at the back-end.
      */
     loadTree({repopath, version, model}) {
-        const repopathv = ise.util.lv(repopath, version);
+        const repopathv = iseUtil.lv(repopath, version);
         if (this.repoIsOpen(repopathv)) return;
         const hub = this.hub;
         const mgr = this;
@@ -276,7 +273,7 @@ export class BuildTreeManager extends TreeManager {
         cm.destroyDescendants();
 
         const tsHome = dojo.domConstruct.create("div");
-        ise.util.addTailSelector(tsHome, item.libpath.split('.'));
+        iseUtil.addTailSelector(tsHome, item.libpath.split('.'));
         cm.addChild(new dojo.PopupMenuItem({
             label: 'Copy libpath',
             popup: new dojo.ContentPane({
@@ -386,7 +383,7 @@ export class BuildTreeManager extends TreeManager {
             }
         }
 
-        if (ise.util.libpathIsRemote(item.libpath)) {
+        if (iseUtil.libpathIsRemote(item.libpath)) {
             let modpath = item.libpath;
             let sourceRow = null;
             let modIsTerm;
@@ -400,13 +397,13 @@ export class BuildTreeManager extends TreeManager {
                 const parentItem = treeNode.tree.model.store.get(item.parent);
                 modIsTerm = parentItem.isTerminal;
             }
-            const url = ise.util.libpath2remoteHostPageUrl(modpath, version, false, sourceRow, modIsTerm);
+            const url = iseUtil.libpath2remoteHostPageUrl(modpath, version, false, sourceRow, modIsTerm);
             const host = modpath.startsWith('gh.') ? 'GitHub' : 'BitBucket';
             cm.addChild(new dojo.MenuSeparator());
             cm.addChild(new dojo.MenuItem({
                 label: `<span title="${url} (opens in new tab)">View at ${host}</span>`,
                 onClick: function(){
-                    ise.util.openInNewTab(url);
+                    iseUtil.openInNewTab(url);
                 }
             }));
         }
@@ -431,8 +428,8 @@ export class BuildTreeManager extends TreeManager {
      * retrieve the root item for that tree.
      */
     getRootItemForMemberLibpathAndVersion(libpath, version) {
-        const repopath = ise.util.getRepoPart(libpath);
-        const treeUid = ise.util.lv(repopath, version);
+        const repopath = iseUtil.getRepoPart(libpath);
+        const treeUid = iseUtil.lv(repopath, version);
         const store = this.stores.get(treeUid);
         return store.query({id: repopath})[0];
     }
@@ -442,8 +439,8 @@ export class BuildTreeManager extends TreeManager {
      * return: the tree item, or undefined if could not be found
      */
     getItemByLibpathAndVersion(libpath, version) {
-        const repopath = ise.util.getRepoPart(libpath);
-        const treeUid = ise.util.lv(repopath, version);
+        const repopath = iseUtil.getRepoPart(libpath);
+        const treeUid = iseUtil.lv(repopath, version);
         const store = this.stores.get(treeUid);
         return store?.query({id: libpath})[0];
     }
@@ -455,8 +452,8 @@ export class BuildTreeManager extends TreeManager {
      * @return: array of items
      */
     getAllDescendantsByLibpathAndVersion(libpath, version) {
-        const repopath = ise.util.getRepoPart(libpath);
-        const treeUid = ise.util.lv(repopath, version);
+        const repopath = iseUtil.getRepoPart(libpath);
+        const treeUid = iseUtil.lv(repopath, version);
         return this.getAllDescendants(treeUid, libpath);
     }
 

--- a/client/src/trees/FsTreeManager.js
+++ b/client/src/trees/FsTreeManager.js
@@ -15,8 +15,8 @@
  * ------------------------------------------------------------------------- */
 
 import { TreeManager } from "./TreeManager";
+import { util as iseUtil } from "../util";
 
-const ise = {};
 const dojo = {};
 
 define([
@@ -28,7 +28,6 @@ define([
     "dijit/PopupMenuItem",
     "dijit/layout/ContentPane",
     "dijit/ConfirmDialog",
-    "ise/util",
     "dojo/NodeList-traverse",
     "dojo/NodeList-manipulate",
 ], function(
@@ -39,8 +38,7 @@ define([
     MenuItem,
     PopupMenuItem,
     ContentPane,
-    ConfirmDialog,
-    iseUtil,
+    ConfirmDialog
 ) {
     dojo.query = query;
     dojo.on = on;
@@ -50,7 +48,6 @@ define([
     dojo.PopupMenuItem = PopupMenuItem;
     dojo.ContentPane = ContentPane;
     dojo.ConfirmDialog = ConfirmDialog;
-    ise.util = iseUtil;
 });
 
 export class FsTreeManager extends TreeManager {
@@ -92,7 +89,7 @@ export class FsTreeManager extends TreeManager {
         this.dispatch({
             type: 'treeLoaded',
             repopath: repopath,
-            repopathv: ise.util.lv(repopath, "WIP"),
+            repopathv: iseUtil.lv(repopath, "WIP"),
         });
     }
 
@@ -123,7 +120,7 @@ export class FsTreeManager extends TreeManager {
     }
 
     libpath2treeUid(libpath) {
-        return ise.util.getRepoPart(libpath);
+        return iseUtil.getRepoPart(libpath);
     }
 
     lookupItemByLibpathAndType(libpath, type) {
@@ -157,7 +154,7 @@ export class FsTreeManager extends TreeManager {
         cm.destroyDescendants();
 
         const tsHome = dojo.domConstruct.create("div");
-        ise.util.addTailSelector(tsHome, item.libpath.split('.'));
+        iseUtil.addTailSelector(tsHome, item.libpath.split('.'));
         cm.addChild(new dojo.PopupMenuItem({
             label: 'Copy libpath',
             popup: new dojo.ContentPane({
@@ -234,17 +231,17 @@ export class FsTreeManager extends TreeManager {
             }));
         }
 
-        if (ise.util.libpathIsRemote(item.libpath)) {
+        if (iseUtil.libpathIsRemote(item.libpath)) {
             const modpath = item.libpath;
             const isDir = item.type === "DIR";
             const modIsTerm = (!isDir && item.name !== '__.pfsc');
-            const url = ise.util.libpath2remoteHostPageUrl(modpath, "WIP", isDir, null, modIsTerm);
+            const url = iseUtil.libpath2remoteHostPageUrl(modpath, "WIP", isDir, null, modIsTerm);
             const host = modpath.startsWith('gh.') ? 'GitHub' : 'BitBucket';
             cm.addChild(new dojo.MenuSeparator());
             cm.addChild(new dojo.MenuItem({
                 label: `<span title="${url} (opens in new tab)">View at ${host}</span>`,
                 onClick: function(){
-                    ise.util.openInNewTab(url);
+                    iseUtil.openInNewTab(url);
                 }
             }));
         }
@@ -307,7 +304,7 @@ export class FsTreeManager extends TreeManager {
             //onCancel: function() { console.log('cancel'); }
         });
         name_input = dlg.domNode.querySelector('input')
-        ise.util.noCorrect(name_input);
+        iseUtil.noCorrect(name_input);
         dojo.on(name_input, 'keydown', e => {
             if (e.code === "Enter") {
                 dlg.okButton.domNode.querySelector('.dijitButtonNode').click();
@@ -390,7 +387,7 @@ export class FsTreeManager extends TreeManager {
                                     // a bug in Dojo code? Should investigate....
                                     // Until then, our workaround is to reload the subtree rooted at the _parent_
                                     // of the renamed item:
-                                    const parentpath = ise.util.getParentPath(msg.newLibpath);
+                                    const parentpath = iseUtil.getParentPath(msg.newLibpath);
                                     this.reloadSubtree(parentpath, "DIR");
                                 }
                             })
@@ -407,7 +404,7 @@ export class FsTreeManager extends TreeManager {
 
     reloadSubtree(oldLibpath, oldType, newLibpath) {
         newLibpath = newLibpath || oldLibpath;
-        const repopath = ise.util.getRepoPart(oldLibpath);
+        const repopath = iseUtil.getRepoPart(oldLibpath);
         return this.hub.socketManager.xhrFor('loadRepoTree', {
             query: { repopath: repopath, vers: "WIP" },
             handleAs: 'json',

--- a/client/src/trees/RepoManager.js
+++ b/client/src/trees/RepoManager.js
@@ -17,8 +17,8 @@
 import { BuildTreeManager } from "./BuildTreeManager";
 import { FsTreeManager } from "./FsTreeManager";
 import { NodeExpandTask } from "../delayed";
+import { util as iseUtil } from "../util";
 
-const ise = {};
 const dojo = {};
 
 define([
@@ -31,7 +31,6 @@ define([
     "dijit/layout/TabContainer",
     "dijit/layout/ContentPane",
     "dijit/ConfirmDialog",
-    "ise/util",
     "dojo/NodeList-traverse",
     "dojo/NodeList-manipulate",
 ], function(
@@ -43,8 +42,7 @@ define([
     LayoutContainer,
     TabContainer,
     ContentPane,
-    ConfirmDialog,
-    iseUtil,
+    ConfirmDialog
 ) {
     dojo.query = query;
     dojo.on = on;
@@ -55,7 +53,6 @@ define([
     dojo.TabContainer = TabContainer;
     dojo.ContentPane = ContentPane;
     dojo.ConfirmDialog = ConfirmDialog;
-    ise.util = iseUtil;
 });
 
 export class RepoManager {
@@ -169,7 +166,7 @@ export class RepoManager {
 
         // Catch malformed input and alert the user.
         try {
-            ise.util.parseTailVersionedLibpath(repopathv);
+            iseUtil.parseTailVersionedLibpath(repopathv);
         } catch (e) {
             this.hub.errAlert(e.message);
             return;
@@ -222,7 +219,7 @@ export class RepoManager {
      *   if the request results in any asynchronous processing.
      */
     openRepo({repopathv, doBuild, doClone, fail_silently, ignoreBuildTree, ignoreFsTree, defaultVersion = "WIP"}) {
-        let {libpath, version} = ise.util.parseTailVersionedLibpath(repopathv, {
+        let {libpath, version} = iseUtil.parseTailVersionedLibpath(repopathv, {
             defaultVersion: defaultVersion,
         });
         const repopath = libpath;
@@ -302,7 +299,7 @@ export class RepoManager {
                 content: msg,
                 onExecute: function() {
                     mgr.openRepo({
-                        repopathv: ise.util.lv(repopath, version),
+                        repopathv: iseUtil.lv(repopath, version),
                         doBuild: doBuild,
                         doClone: doClone,
                     });
@@ -362,14 +359,14 @@ export class RepoManager {
         // numbered release then the server would also build after cloning, and
         // it would suppress the `repoIsPresent` event in favor of a `repoIsBuilt`
         // event.
-        const repopathv = ise.util.lv(repopath, "WIP");
+        const repopathv = iseUtil.lv(repopath, "WIP");
         this.openRepo({
             repopathv: repopathv,
         });
     }
 
     noteRepoIsBuilt({ repopath, version }) {
-        const repopathv = ise.util.lv(repopath, version);
+        const repopathv = iseUtil.lv(repopath, version);
         if (this.buildMgr.repoIsOpen(repopathv)) {
             this.reloadBuildTree(repopathv);
         } else {
@@ -380,7 +377,7 @@ export class RepoManager {
     }
 
     closeRepo(repopath, version = "WIP") {
-        const repopathv = ise.util.lv(repopath, version);
+        const repopathv = iseUtil.lv(repopath, version);
         this.buildMgr.closeRepo(repopathv);
         this.fsMgr.closeRepo(repopath);
     }
@@ -410,7 +407,7 @@ export class RepoManager {
         const trees = {};
         // repos @WIP:
         for (let [repopath, fsNodeIds] of fs) {
-            const repopathv = ise.util.lv(repopath, "WIP");
+            const repopathv = iseUtil.lv(repopath, "WIP");
             const info = {
                 expand: {
                     fsNodeIds: fsNodeIds,
@@ -490,8 +487,8 @@ export class RepoManager {
      * }
      */
     repoIsLoaded({ repopathv, repopath }) {
-        repopathv = repopathv || ise.util.lv(repopath, "WIP");
-        repopath = repopath || ise.util.parseTailVersionedLibpath(repopathv).libpath;
+        repopathv = repopathv || iseUtil.lv(repopath, "WIP");
+        repopath = repopath || iseUtil.parseTailVersionedLibpath(repopathv).libpath;
         return {
             fs: this.fsMgr.repoIsOpen(repopath),
             build: this.buildMgr.repoIsOpen(repopathv),
@@ -500,7 +497,7 @@ export class RepoManager {
 
     expandNodesPlusAncestors(repopathv, toExpand) {
         if (toExpand.fsNodeIds) {
-            const repopath = ise.util.parseTailVersionedLibpath(repopathv).libpath;
+            const repopath = iseUtil.parseTailVersionedLibpath(repopathv).libpath;
             this.fsMgr.expandNodesPlusAncestors(repopath, toExpand.fsNodeIds);
         }
         if (toExpand.buildNodeIds) {
@@ -525,7 +522,7 @@ export class RepoManager {
         const itemIds = this.fsMgr.findEssentialExpandedIds([repopath]).get(repopath);
         this.fsMgr.closeRepo(repopath);
         return this.openRepo({
-            repopathv: ise.util.lv(repopath, "WIP"),
+            repopathv: iseUtil.lv(repopath, "WIP"),
             ignoreBuildTree: true,
         }).then(resp => {
             if (resp.fs_model) {

--- a/client/src/util.js
+++ b/client/src/util.js
@@ -16,8 +16,8 @@
 
 import { moose } from "pfsc-moose/src/moose/head";
 
-define([], function(){
-var util = {};
+
+export const util = {};
 
 /* Assign property values to a target object from alternative source objects.
  * The source objects are checked, in order, for a defined value of each
@@ -1062,8 +1062,3 @@ util.detachListeners = function(editor, ace) {
     sesh.setDocument(emptyDoc);
     editor.setSession(emptySesh);
 };
-
-// ---------------------------------------------------------------------------
-
-return util;
-});

--- a/client/src/widgets/ChartWidget.js
+++ b/client/src/widgets/ChartWidget.js
@@ -40,17 +40,17 @@ const ChartWidget = declare(NavWidget, {
         this.checkboxes = {};
     },
 
-    getInfoCopy: function() {
+    getInfoCopy: function getInfoCopy() {
         // Start with a deep copy, as in the basic Widget class.
-        var copy = this.inherited(arguments);
+        var copy = this.inherited(getInfoCopy, arguments);
         // Set self as study manager, if there are any checkbox settings.
         if (copy.checkboxes) copy.studyManager = this;
         return copy;
     },
 
-    activate: function(wdq, uid, nm, pane) {
+    activate: function activate(wdq, uid, nm, pane) {
         // Let our superclass set up the click handler.
-        this.inherited(arguments);
+        this.inherited(activate, arguments);
         // If we have hovercolor, set that up.
         const info = this.origInfo;
         if (info.hovercolor) {
@@ -89,9 +89,9 @@ const ChartWidget = declare(NavWidget, {
         }
     },
 
-    updateInfo: function(newInfo) {
+    updateInfo: function updateInfo(newInfo) {
         // Begin by updating both our `origInfo` and `liveInfo` fields, as in the base class.
-        this.inherited(arguments);
+        this.inherited(updateInfo, arguments);
         // Now update checkboxes.
         var cbInfo = this.liveInfo.checkboxes;
         if (!cbInfo) {

--- a/client/src/widgets/DispWidget.js
+++ b/client/src/widgets/DispWidget.js
@@ -20,14 +20,14 @@ require("ace-builds/src-noconflict/theme-tomorrow.js");
 require("ace-builds/src-noconflict/theme-tomorrow_night_eighties.js");
 require("ace-builds/src-noconflict/ext-searchbox.js");
 
+import { util as iseUtil } from "../util";
+
 define([
     "dojo/_base/declare",
-    "ise/widgets/ExampWidget",
-    "ise/util",
+    "ise/widgets/ExampWidget"
 ], function(
     declare,
-    ExampWidget,
-    iseUtil
+    ExampWidget
 ) {
 
 const DispWidget = declare(ExampWidget, {
@@ -82,8 +82,8 @@ const DispWidget = declare(ExampWidget, {
         this.editorsByPaneId.set(pane.id, editors);
     },
 
-    activate: function(wdq, uid, nm, pane) {
-        this.inherited(arguments);
+    activate: function activate(wdq, uid, nm, pane) {
+        this.inherited(activate, arguments);
         const activation = this.activationByPaneId.get(pane.id);
         activation.then(() => {
             // Procede only if the pane still exists. It could have been closed while waiting
@@ -344,8 +344,8 @@ const DispWidget = declare(ExampWidget, {
         }
     },
 
-    noteClosingPane: function(pane) {
-        this.inherited(arguments);
+    noteClosingPane: function noteClosingPane(pane) {
+        this.inherited(noteClosingPane, arguments);
         const paneId = pane.id;
 
         this.destroyEditors(paneId);

--- a/client/src/widgets/ExampWidget.js
+++ b/client/src/widgets/ExampWidget.js
@@ -14,15 +14,15 @@
  *  limitations under the License.                                           *
  * ------------------------------------------------------------------------- */
 
+import { util as iseUtil } from "../util";
+
 define([
     "dojo/_base/declare",
     "ise/widgets/Widget",
-    "ise/util",
     "ise/errors",
 ], function(
     declare,
     Widget,
-    iseUtil,
     iseErrors
 ) {
 
@@ -72,8 +72,8 @@ const ExampWidget = declare(Widget, {
         return this.descendants.has(uid);
     },
 
-    updateInfo: function(newInfo) {
-        this.inherited(arguments);
+    updateInfo: function updateInfo(newInfo) {
+        this.inherited(updateInfo, arguments);
         this.setupDependencyRelations();
     },
 

--- a/client/src/widgets/LabelWidget.js
+++ b/client/src/widgets/LabelWidget.js
@@ -14,6 +14,8 @@
  *  limitations under the License.                                           *
  * ------------------------------------------------------------------------- */
 
+import { util as iseUtil } from "../util";
+
 define([
     "dojo/_base/declare",
     "dojo/dom-construct",
@@ -21,8 +23,7 @@ define([
     "dijit/Menu",
     "dijit/PopupMenuItem",
     "dijit/layout/ContentPane",
-    "ise/widgets/Widget",
-    "ise/util"
+    "ise/widgets/Widget"
 ], function(
     declare,
     domConstruct,
@@ -30,8 +31,7 @@ define([
     Menu,
     PopupMenuItem,
     ContentPane,
-    Widget,
-    iseUtil
+    Widget
 ) {
 
 const LabelWidget = declare(Widget, {

--- a/client/src/widgets/LinkWidget.js
+++ b/client/src/widgets/LinkWidget.js
@@ -14,14 +14,14 @@
  *  limitations under the License.                                           *
  * ------------------------------------------------------------------------- */
 
+import { util as iseUtil } from "../util";
+
 define([
     "dojo/_base/declare",
-    "ise/widgets/Widget",
-    "ise/util"
+    "ise/widgets/Widget"
 ], function(
     declare,
-    Widget,
-    iseUtil
+    Widget
 ) {
 
 var LinkWidget = declare(Widget, {

--- a/client/src/widgets/ParamWidget.js
+++ b/client/src/widgets/ParamWidget.js
@@ -14,18 +14,18 @@
  *  limitations under the License.                                           *
  * ------------------------------------------------------------------------- */
 
+import { util as iseUtil } from "../util";
+
 define([
     "dojo/_base/declare",
     "ise/widgets/ExampWidget",
     "ise/examp/Chooser",
-    "ise/examp/NfChooser",
-    "ise/util",
+    "ise/examp/NfChooser"
 ], function(
     declare,
     ExampWidget,
     Chooser,
-    NfChooser,
-    iseUtil
+    NfChooser
 ) {
 
 const ParamWidget = declare(ExampWidget, {
@@ -107,24 +107,24 @@ const ParamWidget = declare(ExampWidget, {
         return this.receiveNewValue(paneId, newValue, writeHtml);
     },
 
-    grayOut: function(paneId, makeGray) {
-        this.inherited(arguments); // <-- superclass call in Dojo
+    grayOut: function grayOut(paneId, makeGray) {
+        this.inherited(grayOut, arguments); // <-- superclass call in Dojo
         const chooser = this.choosersByPaneId.get(paneId);
         if (chooser) {
             chooser.enable(!makeGray || this.hasError(paneId));
         }
     },
 
-    setErrorMessage: function(paneId, msg) {
-        this.inherited(arguments);
+    setErrorMessage: function setErrorMessage(paneId, msg) {
+        this.inherited(setErrorMessage, arguments);
         const chooser = this.choosersByPaneId.get(paneId);
         if (chooser) {
             chooser.enable(true);
         }
     },
 
-    noteClosingPane: function(pane) {
-        this.inherited(arguments);
+    noteClosingPane: function noteClosingPane(pane) {
+        this.inherited(noteClosingPane, arguments);
         this.choosersByPaneId.delete(pane.id);
     },
 

--- a/client/src/widgets/PdfWidget.js
+++ b/client/src/widgets/PdfWidget.js
@@ -28,9 +28,9 @@ const PdfWidget = declare(NavWidget, {
 
     // Methods
 
-    activate: function(wdq, uid, nm, pane) {
+    activate: function activate(wdq, uid, nm, pane) {
         // Let our superclass set up the click handler.
-        this.inherited(arguments);
+        this.inherited(activate, arguments);
     },
 
 });

--- a/client/src/widgets/Widget.js
+++ b/client/src/widgets/Widget.js
@@ -14,22 +14,22 @@
  *  limitations under the License.                                           *
  * ------------------------------------------------------------------------- */
 
+import { util as iseUtil } from "../util";
+
 define([
     "dojo/_base/declare",
     "dijit/layout/ContentPane",
     "dijit/Menu",
     "dijit/MenuItem",
     "dijit/PopupMenuItem",
-    "dijit/MenuSeparator",
-    "ise/util",
+    "dijit/MenuSeparator"
 ], function(
     declare,
     ContentPane,
     Menu,
     MenuItem,
     PopupMenuItem,
-    MenuSeparator,
-    iseUtil,
+    MenuSeparator
 ) {
 
 var Widget = declare(null, {


### PR DESCRIPTION
This is just an (arguably overdue) update of the way the util module on the client side is packaged.

Along with this, certain new `import` statements caused strict mode, invalidating old usages of Dojo's `inherited()`, and we applied this fix: https://stackoverflow.com/a/53198255