### PR TITLE
s: Bugfix in `PfscDocWidgetDirective`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Improvements:
 * Update management docs
   ([#34](https://github.com/proofscape/pise/pull/34)).
 
+Bug Fixes:
+
+* Make Sphinx doc widgets properly accept libpaths for `sel` field
+  ([#37](https://github.com/proofscape/pise/pull/37)).
+
 
 ## 0.28.0 (230830)
 

--- a/server/pfsc/sphinx/widgets/doc_widget.py
+++ b/server/pfsc/sphinx/widgets/doc_widget.py
@@ -16,6 +16,7 @@
 
 from docutils.parsers.rst.directives import unchanged
 
+from pfsc.lang.freestrings import Libpath
 from pfsc.lang.widgets import DocWidget
 from pfsc.sphinx.widgets.nav_widgets import PfscNavWidgetRole
 from pfsc.sphinx.widgets.base import PfscOneArgWidgetDirective
@@ -39,6 +40,15 @@ class PfscDocWidgetRole(PfscNavWidgetRole):
     widget_class = DocWidget
     widget_type_name = 'doc'
     target_field_name = 'sel'
+
+
+def libpath_or_combiner_code(s):
+    """
+    Pass a string, which should be either a combiner code, or a libpath (potentially
+    relative). We decide which one it is, return it as a `Libpath` instance if we think
+    it's a libpath, or unchanged if we think it's a combiner code.
+    """
+    return s if s.find(';') >= 0 else Libpath(s)
 
 
 class PfscDocWidgetDirective(PfscOneArgWidgetDirective):
@@ -72,5 +82,5 @@ class PfscDocWidgetDirective(PfscOneArgWidgetDirective):
     option_spec = {
         **PfscOneArgWidgetDirective.option_spec,
         "doc": unchanged,
-        "sel": unchanged,
+        "sel": libpath_or_combiner_code,
     }


### PR DESCRIPTION
The `sel` field now returns an actual `Libpath` instance when the value does not appear to be a combiner code. This makes it possible to pass the libpath of a node, in order to share its doc ref (which was broken before).