### PR TITLE
Support forward refs for doc label clones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Bug Fixes:
 
 * Make Sphinx doc widgets properly accept libpaths for `sel` field
   ([#37](https://github.com/proofscape/pise/pull/37)).
+* Support forward references for doc label clones
+  ([#38](https://github.com/proofscape/pise/pull/38)).
 
 
 ## 0.28.0 (230830)

--- a/server/tests/resources/repo/foo/doc/v2/results.pfsc
+++ b/server/tests/resources/repo/foo/doc/v2/results.pfsc
@@ -63,4 +63,24 @@ Next let's make
 libpath, and this is interpreted to mean that we want exactly the same
 selection made by the doc reference on that node. Because the node already
 specified the doc, we do not need a `doc` field here.
+
+We also want to test that we can make
+<doc:>[a "forward" clone reference]{
+    sel: X1.A1
+}, meaning that we can clone from a node that is defined *after* this annotation, in
+the same module.
 @@@
+
+
+deduc X1 of Pf.S {
+
+    docInfo=doc1
+
+    asrt A1 {
+        en = "Something that helps to clarify."
+
+        doc = "v2;s3;(1:1758:2666:400:200:100:50);n;x+35;y+4;(1:1758:2666:400:250:110:49)"
+    }
+
+    meson = "Pf.S by A1 and Pf.R."
+}

--- a/server/tests/test_doc_ref.py
+++ b/server/tests/test_doc_ref.py
@@ -154,7 +154,7 @@ def test_doc_ref_formats_1(app):
 
         widgets = anno['widgets']
         wk = list(widgets.keys())
-        assert len(wk) == 5
+        assert len(wk) == 6
         assert 'sel' not in widgets[wk[0]]
         assert all('sel' in widgets[wk[i]] for i in [1, 2, 3, 4])
         assert all(widgets[wk[i]]['docId'] == 'pdffp:fedcba9876543210' for i in range(5))
@@ -164,7 +164,7 @@ def test_doc_ref_formats_1(app):
 
         refs = anno_doc_info['refs']['pdffp:fedcba9876543210']
 
-        assert len(refs) == 4
+        assert len(refs) == 5
         assert all(
             hld['ccode'] == 'v2;s3;(1:1758:2666:400:200:100:50);n;x+35;y+4;(1:1758:2666:400:250:110:49)'
             for hld in refs
@@ -179,6 +179,11 @@ def test_doc_ref_formats_1(app):
         assert refs[3]['stype'] == 'NOTES'
         assert refs[3]['osiid'] == 'test.foo.doc.results.Pf.R'
         assert refs[3]['oslp'] == 'test.foo.doc.results.Pf'
+
+        # Successfully made a "forward clone," i.e. an anno cloned from a node defined
+        # later than it, in the same module:
+        assert refs[4]['siid'] == 'test-foo-doc-results-Discussion-w5_WIP'
+        assert refs[4]['osiid'] == 'test.foo.doc.results.X1.A1'
 
 
 @pytest.mark.psm


### PR DESCRIPTION
When an annotation defines a doc widget, it is now able to clone from nodes defined *after* the anno, in the same module.