### PR TITLE
Resolve issues with internal links in Sphinx panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Bug Fixes:
   ([#37](https://github.com/proofscape/pise/pull/37)).
 * Support forward references for doc label clones
   ([#38](https://github.com/proofscape/pise/pull/38)).
+* Resolve issues with internal links in Sphinx panels, ensuring location
+  updates are not reset by panel splits or rebuilds
+  ([#41](https://github.com/proofscape/pise/pull/41)).
 
 
 ## 0.28.0 (230830)


### PR DESCRIPTION
Instead of simply allowing the browser to handle internal links, modify them so that we get to handle them programmatically. This allows us to ensure that:

* The iframe's `src` attribute updates. Without this, the panel will jump back to its original page when tab splits are changed and the frame is moved in the DOM.

* The panel updates its "subscription" so that, upon rebuild, we stay at the most recent page (instead of reloading the original).