### PR TITLE
Make Sphinx panels become active upon click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Bug Fixes:
 * Resolve issues with internal links in Sphinx panels, ensuring location
   updates are not reset by panel splits or rebuilds
   ([#41](https://github.com/proofscape/pise/pull/41)).
+* Make Sphinx panels become the active tab, upon internal click
+  ([#42](https://github.com/proofscape/pise/pull/42)).
 
 
 ## 0.28.0 (230830)

--- a/client/src/content_types/notes/SphinxViewer.js
+++ b/client/src/content_types/notes/SphinxViewer.js
@@ -146,6 +146,15 @@ export class SphinxViewer extends BasePageViewer {
             this.observeLocationChange();
         });
 
+        // We want click events happening inside the iframe to bubble up out of the frame,
+        // so that the tab becomes active in PISE, when clicks take place inside of it.
+        this.cw.document.body.addEventListener('click', event => {
+            // Need a new event object, since the browser won't let you dispatch one that
+            // is already being dispatched.
+            const newEvent = new event.constructor(event.type, event);
+            this.iframe.dispatchEvent(newEvent);
+        });
+
         const hub = this.mgr.hub;
         hub.markPyodideLoadedInDocument(this.cw.document, hub.pyodideIsLoaded());
 


### PR DESCRIPTION
Click events in Sphinx panels were getting trapped in the iframe. We now re-dispatch them on the frame element, so that the top window sees them. In particular, the Dojo tab container will see them, and the tab will become the active one.