### PR TITLE
Repair load-and-nav operation for PDF panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Bug Fixes:
   ([#41](https://github.com/proofscape/pise/pull/41)).
 * Make Sphinx panels become the active tab, upon internal click
   ([#42](https://github.com/proofscape/pise/pull/42)).
+* Repair load-and-nav operation for PDF panels
+  ([#44](https://github.com/proofscape/pise/pull/44)).
 
 
 ## 0.28.0 (230830)

--- a/client/src/content_types/pdf/PdfController.js
+++ b/client/src/content_types/pdf/PdfController.js
@@ -911,7 +911,7 @@ var PdfController = declare(null, {
                                 }
                             }
                         }
-                    })
+                    }, {requireHighlightLayer: true});
                 }
             }
         }
@@ -1307,6 +1307,10 @@ var PdfController = declare(null, {
      * param operation: the function that carries out the desired operation.
      *   Should accept a single argument, being a PDFPageView instance representing
      *   the rendered page.
+     * param options: {
+     *   requireHighlightLayer: Set true to require that the highlight layer be
+     *     present, before we will say that a page is rendered. Default false.
+     * }
      *
      * Note that if the page is not currently rendered AND we do not want to autoscroll,
      * then the operation will not be performed.
@@ -1314,14 +1318,18 @@ var PdfController = declare(null, {
      * return: a promise that resolves when we are through with everything we
      *   wanted to do.
      */
-    operateOnRenderedPage: function(pageNumber, doAutoScroll, operation) {
+    operateOnRenderedPage: function(pageNumber, doAutoScroll, operation, options) {
+        const {
+            requireHighlightLayer = false,
+        } = options || {};
         var pageIdx = pageNumber - 1;
         var view = this.viewer.getPageView(pageIdx);
         var ctrl = this;
         function performScroll() {
             ctrl.viewer.scrollPageIntoView({pageNumber: pageNumber});
         }
-        if (!view.canvas || !view.textLayer) {
+        const hlNotOkay = !!requireHighlightLayer && !view.div.querySelector('.highlightLayer');
+        if (!view.canvas || !view.textLayer || hlNotOkay) {
             // The page isn't rendered yet.
             if (doAutoScroll) {
                 var renderPage = new Promise((resolve, reject) => {


### PR DESCRIPTION
Immediate nav to named highlight after loading a doc was broken, as we were trying to select the highlight before the highlight layer had been added to the page.