### PR TITLE
Debug issue with extra rewrites on Sphinx rebuilds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ Bug Fixes:
   ([#44](https://github.com/proofscape/pise/pull/44)).
 * Make doc panels enter enrichments mode before auto-navigating to highlights
   ([#45](https://github.com/proofscape/pise/pull/45)).
+* Debug issue with extra rewrites on Sphinx rebuilds, wherein certain unchanged
+  pages were becoming broken (due to losing required Proofscape data object)
+  ([#46](https://github.com/proofscape/pise/pull/46)).
 
 
 ## 0.28.0 (230830)

--- a/server/pfsc/constants.py
+++ b/server/pfsc/constants.py
@@ -130,6 +130,12 @@ RST_EXT = '.rst'
 # Extension used for pickled cache files
 PICKLE_EXT = '.pickle'
 
+# These are the names of "special" pages that Sphinx generates, which must
+# therefore not have user-defined rst files at the root level of a repo.
+PROHIBITED_RST_DOCNAMES = [
+    'genindex', 'search',
+]
+
 
 class ContentDescriptorType:
     """


### PR DESCRIPTION
On rebuilds, Sphinx may rewrite some docs that were not changed, such as the "toctree-containing files that may have changed", added in `sphinx.builders.Builder.write()`.

In our `get_sphinx_page()` function, we need to load these modules (instead of just failing silently), or else our `inject_page_data()` function will fail to set the `window.pfsc_page_data` in these pages, resulting in all these pages being broken (PISE will fail to reload them).