### PR TITLE
Update generation of repo URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Breaking Changes:
 
 * `pdf` widgets are now `doc` widgets
   ([#36](https://github.com/proofscape/pise/pull/36)).
+* Underscores in `owner` and `repo` libpath segments translate to hyphens in remote URLs
+  ([#48](https://github.com/proofscape/pise/pull/48)).
 
 Improvements:
 

--- a/client/src/trees/FsTreeManager.js
+++ b/client/src/trees/FsTreeManager.js
@@ -235,7 +235,10 @@ export class FsTreeManager extends TreeManager {
             const modpath = item.libpath;
             const isDir = item.type === "DIR";
             const modIsTerm = (!isDir && item.name !== '__.pfsc');
-            const url = iseUtil.libpath2remoteHostPageUrl(modpath, "WIP", isDir, null, modIsTerm);
+            const fileExt = isDir ? null : '.' + item.name.split('.')[1];
+            const url = iseUtil.libpath2remoteHostPageUrl(
+                modpath, "WIP", isDir, fileExt, null, modIsTerm
+            );
             const host = modpath.startsWith('gh.') ? 'GitHub' : 'BitBucket';
             cm.addChild(new dojo.MenuSeparator());
             cm.addChild(new dojo.MenuItem({

--- a/server/pfsc/build/repo.py
+++ b/server/pfsc/build/repo.py
@@ -95,9 +95,14 @@ class RepoInfo:
             RepoFamily.GITHUB: 'https://github.com/%(user)s/%(repo)s',
             RepoFamily.BITBUCKET: 'https://bitbucket.org/%(user)s/%(repo)s'
         }[self.family]
+        # Rule: Underscores in the owner and repo segments of a libpath
+        # are replaced by hyphens when building a URL for GitHub or BitBucket.
+        # GitHub allows hyphens but not underscores in usernames, so that one has to change.
+        # Hyphens also seem to be more popular than underscores in repo names, generally,
+        # so we extend the rule there too.
         url = fmt % {
-            'user': self.user,
-            'repo': self.project
+            'user': self.user.replace('_', '-'),
+            'repo': self.project.replace('_', '-')
         }
         return url
 


### PR DESCRIPTION
* Implement the rule mapping underscores to hyphens in owner and repo segments.

* Repair issues with "Sphinx page lifting" in the repo models underlying structure trees on the client side.