### PR TITLE
Bugfix in linking dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ Bug Fixes:
 * Debug issue with extra rewrites on Sphinx rebuilds, wherein certain unchanged
   pages were becoming broken (due to losing required Proofscape data object)
   ([#46](https://github.com/proofscape/pise/pull/46)).
+* Repair issues with the linking dialog, in the case that the only existing
+  link is a tree-link
+  ([#49](https://github.com/proofscape/pise/pull/49)).
 
 
 ## 0.28.0 (230830)

--- a/client/src/content_types/pdf/PdfController.js
+++ b/client/src/content_types/pdf/PdfController.js
@@ -436,6 +436,13 @@ var PdfController = declare(null, {
         return info;
     },
 
+    getLinkedTreeItem: function() {
+        return {
+            libpath: this.linkedTreeItemLibpath,
+            version: this.linkedTreeItemVersion,
+        };
+    },
+
     /* Request state according to an info object of the kind returned by
      * our `describeState` method.
      *

--- a/client/src/content_types/pdf/PdfManager.js
+++ b/client/src/content_types/pdf/PdfManager.js
@@ -339,6 +339,11 @@ var PdfManager = declare(AbstractContentManager, {
         return pdfc?.docId;
     },
 
+    getLinkedTreeItemForPaneId: function(paneId) {
+        const pdfc = this.pdfcsByPaneId[paneId];
+        return pdfc.getLinkedTreeItem();
+    },
+
     /* Given an array of panes, return the PdfController for the most recently
      * active one. If the array is empty, return null.
      */

--- a/client/src/mgr/ContentManager.js
+++ b/client/src/mgr/ContentManager.js
@@ -387,6 +387,23 @@ var ContentManager = declare(null, {
         return linkingMap.localComponent.getTriples({u: uuid});
     },
 
+    localPaneHasOutgoingLinks: function(paneId) {
+        // Is it a doc pane, with a linked tree item? Have to treat this case
+        // specially, because in this case we do have a link that can be managed
+        // in the linking dialog, even though at the moment it may be that no
+        // actual link triples are currently *loaded* into the panel.
+        const contentType = this.getContentTypeOfLocalPane(paneId);
+        if (contentType === this.crType.PDF) {
+            const mgr = this.getManager(contentType);
+            const item = mgr.getLinkedTreeItemForPaneId(paneId);
+            if (item.libpath) {
+                return true;
+            }
+        }
+        // Otherwise, do we have outgoing link triples?
+        return this.getOutgoingLinkTriplesForLocalPane(paneId).length > 0;
+    },
+
     /*
      * Make a title for a tab.
      *
@@ -682,7 +699,7 @@ var ContentManager = declare(null, {
         menu.pfsc_ise_editSrcItem.set('disabled', !this.editableTypes.includes(info.type));
         menu.pfsc_ise_editSrcItem.set('label', `${isWIP ? "Edit" : "View"} Source`);
         menu.pfsc_ise_studyPageItem.set('disabled', !this.studyPageTypes.includes(info.type));
-        menu.pfsc_ise_linksItem.set('disabled', this.getOutgoingLinkTriplesForLocalPane(pane.id).length === 0);
+        menu.pfsc_ise_linksItem.set('disabled', !this.localPaneHasOutgoingLinks(pane.id));
         menu.pfsc_ise_linksItem.set('onClick', event => {
             this.showLinkingDialog(pane.id);
         });
@@ -1406,7 +1423,7 @@ var ContentManager = declare(null, {
 
         let existingLinkTab;
         let existingTreeItemLabel;
-        if (n > 0) {
+        if (n > 0 || existingTreeItem) {
             // Source tab always gets label "A". If target given, it gets "B", while
             // existing targets start at "C"; else the latter start at "B".
             let q = 0;


### PR DESCRIPTION
* Ensure that the `Links...` item is active in the tab context menu, in the case that the only existing link is a tree link, with no triples currently loaded into the panel.
* Ensure that the linking dialog then shows the link, in this case (was reporting "no existing links").