### PR TITLE
Repair misc. issues in linking dialog for trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ Bug Fixes:
 * Repair issues with the linking dialog, in the case that the only existing
   link is a tree-link
   ([#49](https://github.com/proofscape/pise/pull/49)).
+* Repair issues with the linking dialog, when adding new tree-links
+  ([#50](https://github.com/proofscape/pise/pull/50)).
 
 
 ## 0.28.0 (230830)

--- a/client/src/mgr/ContentManager.js
+++ b/client/src/mgr/ContentManager.js
@@ -1326,15 +1326,18 @@ var ContentManager = declare(null, {
             }
         }
 
+        const sayAlreadyLinked = () => {
+            this.hub.alert({
+                title: "Linking",
+                content: "Already linked!",
+            });
+        }
+
         const existingLinks = this.getOutgoingLinkTriplesForLocalPane(sourceId);
         const existingTargetInfos = new Map();
         for (const [u, x, w] of existingLinks) {
             if (w === tUuid) {
-                // Already linked
-                this.hub.alert({
-                    title: "Linking",
-                    content: "Already linked!",
-                });
+                sayAlreadyLinked();
                 return;
             }
             const info = await this.getPaneInfoByUuidAllWindows(w);
@@ -1362,7 +1365,7 @@ var ContentManager = declare(null, {
         const sourceLabel = "A";
 
         function makeCheckboxId(targetLabel) {
-            return `linkingDialog--${targetLabel.replaceAll('.', '-')}`;
+            return `linkingDialog--${targetLabel.replaceAll('@', '--').replaceAll('.', '-')}`;
         }
 
         function buildLinkRow(targetColor, targetLabel, options) {
@@ -1405,6 +1408,16 @@ var ContentManager = declare(null, {
             return label;
         }
 
+        if (
+            targetTreeItem && existingTreeItem &&
+            writeTreeItemLabel(targetTreeItem) === writeTreeItemLabel(existingTreeItem)
+        ) {
+            sayAlreadyLinked();
+            return;
+        }
+
+        const thereAreAlternatives = n > 0 || !!existingTreeItem;
+
         let proposedLinkTab;
         let targetColor;
         let targetLabel;
@@ -1417,13 +1430,13 @@ var ContentManager = declare(null, {
         }
         if (targetLabel) {
             proposedLinkTab = buildLinkTable(
-                [buildLinkRow(targetColor, targetLabel, {includeCheckbox: n > 0})]
+                [buildLinkRow(targetColor, targetLabel, {includeCheckbox: thereAreAlternatives})]
             );
         }
 
         let existingLinkTab;
         let existingTreeItemLabel;
-        if (n > 0 || existingTreeItem) {
+        if (thereAreAlternatives) {
             // Source tab always gets label "A". If target given, it gets "B", while
             // existing targets start at "C"; else the latter start at "B".
             let q = 0;

--- a/client/src/trees/BuildTreeManager.js
+++ b/client/src/trees/BuildTreeManager.js
@@ -100,7 +100,7 @@ export class BuildTreeManager extends TreeManager {
                     if (cl.startsWith(libpathClassPrefix)) {
                         const p = cl.split('--');
                         libpath = p[1].replaceAll('-', '.');
-                        version = p[2];
+                        version = p[2].replaceAll('_', '.');
                     }
                 }
 
@@ -135,7 +135,7 @@ export class BuildTreeManager extends TreeManager {
      * by this tree node.
      */
     makeTreeIconLibpathClass(libpath, version) {
-        return `${libpathClassPrefix}--${libpath.replaceAll('.', '-')}--${version}`;
+        return `${libpathClassPrefix}--${libpath.replaceAll('.', '-')}--${version.replaceAll('.', '_')}`;
     }
 
     /* Given the data describing a repo tree model, load and display this repo tree.


### PR DESCRIPTION
* When linking to a tree at a numbered version:
  - We need to replace `@` and `.` chars with chars acceptable in HTML class names and id's.

* When linking to a tree at any version:
  - We were failing to reject the case where we were already linked to that tree.
  - We were failing to generate one checkbox when there were exactly two alternatives, both of which were trees.