### PR TITLE
Update Sphinx widget code re subtext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Breaking Changes:
   ([#36](https://github.com/proofscape/pise/pull/36)).
 * Underscores in `owner` and `repo` libpath segments translate to hyphens in remote URLs
   ([#48](https://github.com/proofscape/pise/pull/48)).
+* Require colon after name in Sphinx widgets that do not accept a label
+  ([#51](https://github.com/proofscape/pise/pull/51)).
 
 Improvements:
 

--- a/server/pfsc/sphinx/widgets/nav_widgets.py
+++ b/server/pfsc/sphinx/widgets/nav_widgets.py
@@ -19,14 +19,14 @@ import re
 from sphinx.util.docutils import SphinxRole
 
 from pfsc.sphinx.widgets.base import finish_run
-from pfsc.sphinx.widgets.util import process_widget_label
+from pfsc.sphinx.widgets.util import process_widget_subtext
 from pfsc.excep import PfscExcep
 
 
 class PfscNavWidgetRole(SphinxRole):
     """
     A simple, inline syntax for minimal nav widgets:
-        - The label may optionally begin with a widget name.
+        - The SUBTEXT may optionally begin with a widget NAME.
         - Must define exactly one "target" field, which maps onto an
             appropriate field for each subclass (e.g. the `view` field
             for chart widgets).
@@ -50,15 +50,15 @@ class PfscNavWidgetRole(SphinxRole):
         if not M:
             return self.write_error_return_values(
                 f'Inline Proofscape {self.widget_type_name} widgets must have'
-                f' the form `LABEL <{self.target_field_name.upper()}>`.'
+                f' the form `SUBTEXT <{self.target_field_name.upper()}>`.'
             )
-        raw_label, target = [g.strip() for g in M.groups()]
+        subtext, target = [g.strip() for g in M.groups()]
 
         try:
-            widget_name, final_label_text = process_widget_label(raw_label)
+            widget_name, widget_label = process_widget_subtext(subtext)
         except PfscExcep:
             return self.write_error_return_values(
-                'Widget name (text before colon) malformed.'
+                'Widget name (text before colon in subtext) malformed.'
                 ' Must be valid libpath segment, or empty.'
             )
 
@@ -68,7 +68,7 @@ class PfscNavWidgetRole(SphinxRole):
 
         node = finish_run(
             self, self.widget_class,
-            self.rawtext, final_label_text, fields,
+            self.rawtext, widget_label, fields,
             widget_name=widget_name
         )
         return [node], []

--- a/server/pfsc/sphinx/widgets/util.py
+++ b/server/pfsc/sphinx/widgets/util.py
@@ -22,47 +22,46 @@ from pfsc.excep import PfscExcep, PECode
 from pfsc.checkinput import check_boxlisting, check_libseg, check_dict
 
 
-def process_widget_label(raw_label):
+def process_widget_subtext(subtext):
     """
-    Process a raw widget label, extracting an optional widget name, and
-    stripping external whitespace.
+    Process a widget SUBTEXT, separating into NAME and/or LABEL, and stripping external whitespace.
 
-    * If the raw label does not contain any colons, then the entire thing (stripped of external
-        whitespace) is the final label, and the widget gets a system-supplied name.
+    * If the SUBTEXT does not contain any colons, then the entire thing (stripped of external
+        whitespace) is the LABEL, and the widget gets a system-supplied NAME.
 
-    * If the raw label does contain one or more colons, then everything coming before the
-        *first* one must be either a valid widget name, or empty (otherwise it's an error).
+    * If the SUBTEXT does contain one or more colons, then everything coming before the
+        *first* one must be either a valid widget NAME, or empty (otherwise it's an error).
 
         In the first case, the widget takes the given name; in the second case, the system
         supplies one.
 
         In all cases, everything up to and including the first colon will be deleted, external
-        whitespace will be stripped from what remains, and that will be the final label text.
+        whitespace will be stripped from what remains, and that will be the final LABEL.
 
-    :returns: pair (name, text) being the widget name (possibly None, possibly empty string),
-        and final label text
-    :raises: PfscExcep if the raw text contains a colon, but what comes before
+    :returns: pair (name, label) being the widget NAME (possibly None, possibly empty string),
+        and widget LABEL (possibly empty string)
+    :raises: PfscExcep if the SUBTEXT contains a colon, but what comes before
         the first colon is neither empty nor a valid libpath segment.
     """
     name = None
-    text = raw_label
+    label = subtext
 
     # If there is a colon...
-    i0 = raw_label.find(":")
+    i0 = subtext.find(":")
     if i0 >= 0:
         # ...and if the text up to the first colon is either empty or a valid libseg...
-        prefix = raw_label[:i0]
+        prefix = subtext[:i0]
         if i0 > 0:
             check_widget_name(prefix)
         # ...then that prefix is the widget name, while everything coming
-        # *after* the colon, minus external whitespace, is the text.
+        # *after* the colon, minus external whitespace, is the label.
         name = prefix
-        text = raw_label[i0 + 1:]
+        label = subtext[i0 + 1:]
 
-    # Strip external whitespace off the text.
-    text = text.strip()
+    # Strip external whitespace off of what remains.
+    label = label.strip()
 
-    return name, text
+    return name, label
 
 
 def check_widget_name(raw):

--- a/server/tests/resources/repo/spx/doc1/v0.1.0/foo/pageC.rst
+++ b/server/tests/resources/repo/spx/doc1/v0.1.0/foo/pageC.rst
@@ -15,6 +15,8 @@ Let's try another inline :pfsc-chart:`chart widget <Pf>`.
 And confirm that the auto-generated numbers for these
 :pfsc-chart:`chart widgets <Thm>` are properly incrementing.
 
+Let's also have an inline one where we specify the name,
+:pfsc-chart:`name1: like this <Thm.C>`.
 
 Next we try defining chart widgets using the full directive form.
 We still want the links they generate to be inline, so we're supposed
@@ -29,7 +31,14 @@ to be sure that rST will accept a substitution text with a leading colon,
 the final label text contain a colon, while *also* having the system supply the
 widget name for you.
 
-Now we'll need a series of chart widgets, for unit tests.
+It probably won't be too common in actual usage, but let's at least see that we
+*can* write a chart widget in pure *directive format* (not *substitution format*):
+
+.. pfsc-chart:: name2: This is a standalone chart widget.
+    :view: Pf
+
+Finally, we'll need a series of chart widgets, to test the various options
+that can be passed to them.
 
 |w001: one-line color definition|
 |w002: color defn with: repeated LHS, plus use of update|

--- a/server/tests/resources/repo/spx/doc1/v0.1.0/foo/pageE.rst
+++ b/server/tests/resources/repo/spx/doc1/v0.1.0/foo/pageE.rst
@@ -12,7 +12,7 @@ This is `another one <https://proofscape.org>`_.
 Examp Widgets
 -------------
 
-.. pfsc-param:: eg1_k
+.. pfsc-param:: eg1_k:
     :ptype: NumberField
     :name: k
     :default: "cyc(7)"
@@ -23,7 +23,7 @@ Examp Widgets
             ]
         bar: false
 
-.. pfsc-disp:: eg1_disp1
+.. pfsc-disp:: eg1_disp1:
     :import:
         k: eg1_k
     :export: B

--- a/server/tests/resources/repo/spx/doc1/v0.1.0/pageA.rst
+++ b/server/tests/resources/repo/spx/doc1/v0.1.0/pageA.rst
@@ -12,7 +12,7 @@ Let's try an inline :pfsc-chart:`proof1: chart widget <Pf>`.
 With these, you can only specify the label, an optional name, and the ``view``
 field.
 
-.. pfsc-qna:: ultimateQuestion
+.. pfsc-qna:: penultimateQuestion:
     :question:
         What is the answer?
     :answer:

--- a/server/tests/test_sphinx.py
+++ b/server/tests/test_sphinx.py
@@ -26,7 +26,7 @@ from pfsc.build.repo import get_repo_info
 from pfsc.build.manifest import load_manifest
 from pfsc.build.products import load_annotation, load_dashgraph
 from pfsc.sphinx.pages import SCRIPT_INTRO, SCRIPT_ID
-from pfsc.sphinx.widgets.util import process_widget_label
+from pfsc.sphinx.widgets.util import process_widget_subtext
 from pfsc.excep import PfscExcep
 
 
@@ -107,26 +107,27 @@ def get_highlights(soup, language):
     return list(soup.find_all('div', class_=f'highlight-{language}'))
 
 
-@pytest.mark.parametrize('raw_label, name0, text0', [
+@pytest.mark.parametrize('subtext, name0, text0', [
+    ['', None, ''],
     ['foo bar ', None, 'foo bar'],
     ['foo: bar ', 'foo', 'bar'],
     ['myGreatWidget: foo: bar', 'myGreatWidget', 'foo: bar'],
     [': foo: bar', '', 'foo: bar'],
     [':foo: bar', '', 'foo: bar'],
-
+    ['foo:', 'foo', ''],
 ])
-def test_process_widget_label(raw_label, name0, text0):
-    name1, text1 = process_widget_label(raw_label)
+def test_process_widget_subtext(subtext, name0, text0):
+    name1, text1 = process_widget_subtext(subtext)
     assert name1 == name0
     assert text1 == text0
 
 
-@pytest.mark.parametrize('raw_label', [
+@pytest.mark.parametrize('subtext', [
     '23w: the proof',
 ])
-def test_process_widget_label_exception(raw_label):
+def test_process_widget_subtext_exception(subtext):
     with pytest.raises(PfscExcep):
-        process_widget_label(raw_label)
+        process_widget_subtext(subtext)
 
 
 expected_widget_data_spx_doc0 = json.loads("""
@@ -216,7 +217,7 @@ def test_spx_doc1(app):
 
         D = get_qna_widget_divs(soup)
         assert len(D) == 1
-        assert f'test-spx-doc1-pageA-_page-ultimateQuestion_v0-1-0' in D[0].get('class')
+        assert f'test-spx-doc1-pageA-_page-penultimateQuestion_v0-1-0' in D[0].get('class')
     
         # Defines the expected pfsc_page_data
         page_data = get_page_data_from_script_tag(soup)
@@ -315,13 +316,13 @@ PAGE_A_PAGE_DATA = {
             "icon_type": "nav",
             "version": "v0.1.0"
         },
-        "test-spx-doc1-pageA-_page-ultimateQuestion_v0-1-0": {
+        "test-spx-doc1-pageA-_page-penultimateQuestion_v0-1-0": {
             "question": "What is the answer?",
             "answer": "42",
             "type": "QNA",
             "src_line": 15,
-            "widget_libpath": "test.spx.doc1.pageA._page.ultimateQuestion",
-            "uid": "test-spx-doc1-pageA-_page-ultimateQuestion_v0-1-0",
+            "widget_libpath": "test.spx.doc1.pageA._page.penultimateQuestion",
+            "uid": "test-spx-doc1-pageA-_page-penultimateQuestion_v0-1-0",
             "version": "v0.1.0"
         }
     },
@@ -332,14 +333,16 @@ PAGE_A_PAGE_DATA = {
 }
 
 PAGE_C_WIDGET_NAMES = [
-    '_w0', '_w1', 'w000', '_w2', 'w001', 'w002'
+    '_w0', '_w1', 'name1', 'w000', '_w2', 'name2', 'w001', 'w002'
 ]
 
 PAGE_C_WIDGET_LABELS = [
     'chart widget',
     'chart widgets',
+    'like this',
     'substitutions',
     'like: this one',
+    'This is a standalone chart widget.',
     'one-line color definition',
     'color defn with: repeated LHS, plus use of update',
 ]
@@ -376,13 +379,43 @@ PAGE_C_PAGE_DATA = {
             "icon_type": "nav",
             "version": "v0.1.0"
         },
+        "test-spx-doc1-foo-pageC-_page-name1_v0-1-0": {
+            "view": "test.moo.bar.results.Thm.C",
+            "type": "CHART",
+            "src_line": 18,
+            "widget_libpath": "test.spx.doc1.foo.pageC._page.name1",
+            "uid": "test-spx-doc1-foo-pageC-_page-name1_v0-1-0",
+            "pane_group": "test.spx.doc1@v0_1_0.foo.pageC._page:CHART:",
+            "versions": {
+                "test.moo.bar": "v1.0.0"
+            },
+            "title_libpath": "test.spx.doc1.foo.pageC._page",
+            "icon_type": "nav",
+            "version": "v0.1.0"
+        },
+        "test-spx-doc1-foo-pageC-_page-name2_v0-1-0": {
+            "view": [
+                "test.moo.bar.results.Pf"
+            ],
+            "type": "CHART",
+            "src_line": 37,
+            "widget_libpath": "test.spx.doc1.foo.pageC._page.name2",
+            "uid": "test-spx-doc1-foo-pageC-_page-name2_v0-1-0",
+            "pane_group": "test.spx.doc1@v0_1_0.foo.pageC._page:CHART:",
+            "versions": {
+                "test.moo.bar": "v1.0.0"
+            },
+            "title_libpath": "test.spx.doc1.foo.pageC._page",
+            "icon_type": "nav",
+            "version": "v0.1.0"
+        },
         "test-spx-doc1-foo-pageC-_page-_w2_v0-1-0": {
             "alt": ": like: this one",
             "view": [
                 "test.moo.bar.results.Pf"
             ],
             "type": "CHART",
-            "src_line": 38,
+            "src_line": 47,
             "widget_libpath": "test.spx.doc1.foo.pageC._page._w2",
             "uid": "test-spx-doc1-foo-pageC-_page-_w2_v0-1-0",
             "pane_group": "test.spx.doc1@v0_1_0.foo.pageC._page:CHART:",
@@ -412,7 +445,7 @@ PAGE_C_PAGE_DATA = {
                 ]
             },
             "type": "CHART",
-            "src_line": 41,
+            "src_line": 50,
             "widget_libpath": "test.spx.doc1.foo.pageC._page.w000",
             "uid": "test-spx-doc1-foo-pageC-_page-w000_v0-1-0",
             "pane_group": "test.spx.doc1@v0_1_0.foo.pageC._page:CHART:",
@@ -436,7 +469,7 @@ PAGE_C_PAGE_DATA = {
                 ]
             },
             "type": "CHART",
-            "src_line": 49,
+            "src_line": 58,
             "widget_libpath": "test.spx.doc1.foo.pageC._page.w001",
             "uid": "test-spx-doc1-foo-pageC-_page-w001_v0-1-0",
             "pane_group": "test.spx.doc1@v0_1_0.foo.pageC._page:CHART:",
@@ -458,7 +491,7 @@ PAGE_C_PAGE_DATA = {
                 ":update": True
             },
             "type": "CHART",
-            "src_line": 53,
+            "src_line": 62,
             "widget_libpath": "test.spx.doc1.foo.pageC._page.w002",
             "uid": "test-spx-doc1-foo-pageC-_page-w002_v0-1-0",
             "pane_group": "test.spx.doc1@v0_1_0.foo.pageC._page:CHART:",
@@ -470,7 +503,10 @@ PAGE_C_PAGE_DATA = {
             "version": "v0.1.0"
         }
     },
-    "docInfo": {'docs': {}, 'refs': {}}
+    "docInfo": {
+        "docs": {},
+        "refs": {}
+    }
 }
 
 PAGE_D_WIDGET_NAMES = [


### PR DESCRIPTION
* Make the `SUBTEXT` format universal, in all of the Sphinx widget formats.
  In particular, this means a colon is now required after the `NAME` in widgets that
  do not accept a `LABEL`.

* Redo variable names to reflect the three terms `SUBTEXT`, `NAME`, and `LABEL`.