### PR TITLE
Bugfix in `LinkWidget`

### DIFF
--- a/client/src/widgets/LinkWidget.js
+++ b/client/src/widgets/LinkWidget.js
@@ -76,7 +76,7 @@ var LinkWidget = declare(Widget, {
         if (loadingPane === null) {
             // There is no existing pane where we want to load the content,
             // so open it beside the current tab.
-            nm.hub.contentManager.openContentBeside(targetInfo, pane);
+            nm.hub.contentManager.openContentBeside(targetInfo, pane.domNode);
         } else {
             // There already is a pane where we want to load the content.
             const makeActive = true;


### PR DESCRIPTION
The changes to the `LinkWidget` class in commit 88c2492 of 230525 were not adequately tested, and the call to spawn a neighboring panel had a bug, in that we passed a Dijit pane itself, instead of its DOM element.