### PR TITLE
s: Use `invoke` pkg to simplify testing

### DIFF
--- a/server/req/dev-requirements.in
+++ b/server/req/dev-requirements.in
@@ -8,3 +8,4 @@
 
 pip-tools==7.3.0
 rq-dashboard==0.6.1
+invoke==2.2.0

--- a/server/req/dev-requirements.txt
+++ b/server/req/dev-requirements.txt
@@ -38,6 +38,10 @@ importlib-metadata==6.8.0 \
     # via
     #   -c requirements.txt
     #   flask
+invoke==2.2.0 \
+    --hash=sha256:6ea924cc53d4f78e3d98bc436b08069a03077e6f85ad1ddaa8a116d7dad15820 \
+    --hash=sha256:ee6cbb101af1a859c7fe84f2a264c059020b0cb7fe3535f9424300ab568f6bd5
+    # via -r dev-requirements.in
 itsdangerous==2.1.2 \
     --hash=sha256:2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44 \
     --hash=sha256:5dbbc68b317e5e42f327f9021763545dc3fc3bfe22e6deb96aaf1fc38874156a

--- a/server/tasks.py
+++ b/server/tasks.py
@@ -1,0 +1,47 @@
+from invoke import task
+
+
+@task
+def mtr(c):
+    """
+    mtr = "make test repos"
+
+    This generates the git repos under `lib/test`, that are used in the unit tests.
+
+    I'm setting `pty=True` in this and other commands, because I want to recover
+    the familiar behavior where we see the generated output *as the process works*,
+    rather than having it all be buffered and suddenly dumped at the end.
+
+    See:
+        https://docs.pyinvoke.org/en/stable/api/runners.html#invoke.runners.Runner.run
+    """
+    c.run("python -m tests.util.make_repos", pty=True)
+
+
+@task
+def btr(c):
+    """
+    btr = "build test repos"
+
+    After you have used the `mtr` command to generate the git repos under `lib/test`,
+    this command builds each of them, as a Proofscape repo, generating output under
+    the `build` dir.
+
+    You have to run this before you can run the server's unit tests.
+    But this step should be regarded as more than just a prerequisite for unit testing;
+    it is, in itself, the first major test, because it carries out the entire build
+    process on several Proofscape repos. If you are doing development work on the build
+    system, you can expect the `btr` command to flush out many issues.
+    """
+    c.run("python -m tests.util.build_repos", pty=True)
+
+
+@task
+def unit(c):
+    """
+    Run the unit tests.
+
+    You have to run `mtr` and `btr` (in that order) before you can run the unit tests.
+    But those commands only have to be run once, unless the test repos are changed.
+    """
+    c.run("pytest tests", pty=True)


### PR DESCRIPTION
By defining some *task* functions, we can (a) have easy CLI commands to make and build the test repos, and (b) record some docstrings that explain these steps.