### PR TITLE
Fixes and changes for unnamed widgets

### DIFF
--- a/changelog.d/skieffer.unnamed-widgets.branchnews.changed.txt
+++ b/changelog.d/skieffer.unnamed-widgets.branchnews.changed.txt
@@ -1,0 +1,2 @@
+* Authors must supply names for `goal` widgets.
+

--- a/changelog.d/skieffer.unnamed-widgets.branchnews.fixed.txt
+++ b/changelog.d/skieffer.unnamed-widgets.branchnews.fixed.txt
@@ -1,1 +1,3 @@
-Auto-generated widget names in annotations now begin with underscore.
+* Auto-generated widget names in annotations now begin with underscore.
+* Authors must supply names for `goal` widgets.
+

--- a/changelog.d/skieffer.unnamed-widgets.branchnews.fixed.txt
+++ b/changelog.d/skieffer.unnamed-widgets.branchnews.fixed.txt
@@ -1,3 +1,2 @@
 * Auto-generated widget names in annotations now begin with underscore.
-* Authors must supply names for `goal` widgets.
 

--- a/changelog.d/skieffer.unnamed-widgets.branchnews.fixed.txt
+++ b/changelog.d/skieffer.unnamed-widgets.branchnews.fixed.txt
@@ -1,0 +1,1 @@
+Auto-generated widget names in annotations now begin with underscore.

--- a/server/pfsc/lang/freestrings.py
+++ b/server/pfsc/lang/freestrings.py
@@ -389,29 +389,13 @@ def split_on_widgets(text, supply_missing_names=True):
 
     # Do we need to supply missing names?
     if indices_of_missing_names:
-        # Yes, there are names to be supplied.
-        # All generated names will be of the form `w<n>` where n is a positive integer.
-        # First we must determine which such names are already taken. And here we are
-        # case-insensitive on the leading `w`.
-        used_nums = set()
-        for name in names:
-            if len(name) >= 2 and name[0] in 'wW' and name[1] != '0':
-                try:
-                    n = int(name[1:])
-                except ValueError:
-                    pass
-                else:
-                    used_nums.add(n)
-        def next_num(used):
-            n = 1
-            while True:
-                while n in used: n += 1
-                yield n
-                n += 1
-        for k, n in zip(indices_of_missing_names, next_num(used_nums)):
+        # All generated names will be of the form `_w<n>` where n is a non-negative integer.
+        # The `WIDGET_RE` guarantees that no user-supplied name begins with an underscore,
+        # so there is no risk of collision.
+        for n, k in enumerate(indices_of_missing_names):
             rwd = parts[2*k+1]
-            parts[2*k+1] = rwd._replace(name='w%s' % n)
-    # Return the parts.
+            parts[2*k+1] = rwd._replace(name=f'_w{n}')
+
     return parts
 
 ###############################################################################

--- a/server/pfsc/lang/widgets.py
+++ b/server/pfsc/lang/widgets.py
@@ -324,6 +324,21 @@ class Widget(PfscObj):
 
     def cascadeLibpaths(self):
         PfscObj.cascadeLibpaths(self)
+        self.check_name()
+
+    def check_name(self):
+        if (
+            self.type_ in WIDGET_TYPES_REQUIRING_AUTHOR_SUPPLIED_NAME and
+            self.name.startswith("_") and
+            # Goal widgets in study pages need not have pre-determined names,
+            # so exclude libpaths starting with `special.`.
+            not self.libpath.startswith('special.')
+        ):
+            msg = (
+                f'Widgets of type "{self.type_}" require a name.'
+                f' See widget at line {self.lineno}.'
+            )
+            raise PfscExcep(msg, PECode.WIDGET_MISSING_NAME)
 
     def resolve(self):
         self.check_fields()
@@ -1789,4 +1804,11 @@ WIDGET_TYPE_TO_CLASS = {
     WidgetTypes.GOAL:  GoalWidget,
     WidgetTypes.PARAM: ParamWidget,
     WidgetTypes.DOC:   DocWidget,
+}
+
+# At this time authors are required to supply a name only for `goal` widgets.
+# This is to promote stability of users' checkmarks and study notes, and the ability
+# to carry these forward across major version changes, using the move mapping.
+WIDGET_TYPES_REQUIRING_AUTHOR_SUPPLIED_NAME = {
+    WidgetTypes.GOAL
 }

--- a/server/tests/resources/repo/moo/comment/v0.1.0/bar.pfsc
+++ b/server/tests/resources/repo/moo/comment/v0.1.0/bar.pfsc
@@ -7,6 +7,9 @@ anno NotesS on Pf.S @@@
 These are some notes on node `S` in the proof.
 
 And <goal:w1>[this]{} is a goal widget.
+
+This <chart:>[unnamed widget]{coords: [0, 0, 1]} is here to trigger
+a system-generated name.
 @@@
 
 deduc xpan_S of Pf.S {
@@ -35,3 +38,8 @@ deduc xpan_T of Pf.T {
     "
 
 }
+
+anno NotesU @@@
+This <chart:>[unnamed widget]{coords: [0, 0, 1]} is here to trigger
+a system-generated name.
+@@@

--- a/server/tests/resources/repo/moo/comment/v0.1.0/bar.pfsc
+++ b/server/tests/resources/repo/moo/comment/v0.1.0/bar.pfsc
@@ -6,7 +6,7 @@ from test.moo.bar.results import Pf
 anno NotesS on Pf.S @@@
 These are some notes on node `S` in the proof.
 
-And <goal:>[this]{} is a goal widget.
+And <goal:w1>[this]{} is a goal widget.
 @@@
 
 deduc xpan_S of Pf.S {

--- a/server/tests/resources/repo/moo/comment/v0.2.0/__.pfsc
+++ b/server/tests/resources/repo/moo/comment/v0.2.0/__.pfsc
@@ -1,3 +1,9 @@
 dependencies = {
     "test.moo.bar": "v1.0.0"
 }
+
+change_log = {
+    "moved": {
+        "bar.NotesU": "bar.NotesU2"
+    }
+}

--- a/server/tests/resources/repo/moo/comment/v0.2.0/bar.pfsc
+++ b/server/tests/resources/repo/moo/comment/v0.2.0/bar.pfsc
@@ -7,6 +7,10 @@ anno NotesS on Pf.S @@@
 These are some notes on node `S` in the proof.
 
 And <goal:w1>[this]{} is a goal widget.
+
+In the previous version, there was a system-named widget here. Its libpath will
+go away in this version, and we are silent about this in the repo's move-mapping,
+but the system should not complain, since the widget was system-named.
 @@@
 
 deduc xpan_S of Pf.S {
@@ -41,3 +45,14 @@ deduc xpan_T of Pf.T {
     "
 
 }
+
+anno NotesU2 @@@
+In the previous version, there was a system-named widget here. Its libpath will
+go away in this version.
+
+This is similar to what we did in `NotesS`, but this time we've also renamed the
+annotation from `NotesU` to `NotesU2`, and declared this renaming in the repo's
+move-mapping. By doing this, we test a different case ("Rbar subseteq M") in the
+`ModuleIndexInfo.cut_add_validate()` method than was tested in `NotesS` (which
+was the "V_minus subseteq Dbar" case).
+@@@

--- a/server/tests/test_doc_ref.py
+++ b/server/tests/test_doc_ref.py
@@ -174,7 +174,7 @@ def test_doc_ref_formats_1(app):
         assert refs[0]["siid"] == "test-foo-doc-results-Discussion-wFoo_WIP"
 
         # Clone widget has its own siid and slp, but also has expected osiid and oslp:
-        assert refs[2]['siid'] == 'test-foo-doc-results-Discussion-w3_WIP'
+        assert refs[2]['siid'] == 'test-foo-doc-results-Discussion-_w2_WIP'
         assert refs[2]['slp'] == 'test.foo.doc.results.Discussion'
         assert refs[2]['stype'] == 'NOTES'
         assert refs[2]['osiid'] == 'test.foo.doc.results.Pf.R'
@@ -182,7 +182,7 @@ def test_doc_ref_formats_1(app):
 
         # Successfully made a "forward clone," i.e. an anno cloned from a node defined
         # later than it, in the same module:
-        assert refs[3]['siid'] == 'test-foo-doc-results-Discussion-w4_WIP'
+        assert refs[3]['siid'] == 'test-foo-doc-results-Discussion-_w3_WIP'
         assert refs[3]['osiid'] == 'test.foo.doc.results.X1.A1'
 
 
@@ -213,7 +213,7 @@ def test_doc_ref_formats_2(app):
 
         assert ref1 == {
             "ccode": "v2;s3;(146:1758:2666:210:450:90:46);",
-            "siid": "test-foo-doc-more-Notes-w1_WIP",
+            "siid": "test-foo-doc-more-Notes-_w0_WIP",
             "slp": "test.foo.doc.more.Notes",
             "stype": "NOTES",
             "osiid": "test.foo.doc.results.Pf.S",
@@ -222,7 +222,7 @@ def test_doc_ref_formats_2(app):
 
         assert ref2 == {
             "ccode": "v2;s3;(1:1758:2666:400:200:100:50);n;x+35;y+4;(1:1758:2666:400:250:110:49)",
-            "siid": "test-foo-doc-more-Notes-w2_WIP",
+            "siid": "test-foo-doc-more-Notes-_w1_WIP",
             "slp": "test.foo.doc.more.Notes",
             "stype": "NOTES",
             "osiid": "test-foo-doc-results-Discussion-wFoo_WIP",

--- a/server/tests/test_freestrings.py
+++ b/server/tests/test_freestrings.py
@@ -289,7 +289,7 @@ def test_widget_split_2():
     print(B.data)
     print(C)
     data = build_json(B.data)
-    assert B.name == 'w1'
+    assert B.name == '_w0'
     assert len(data.keys()) == 2
 
 # ----------------------------------------------------------------------
@@ -310,9 +310,12 @@ def test_supply_names():
         rwd = parts[2*k+1]
         print(rwd.name)
         names.append(rwd.name)
-    expected = [2, 1, 3, 4, 6, 5, 7, 8]
+    expected = [0, 1, 3, 4, 6, -1, -2, -3]
     for name, n in zip(names, expected):
-        assert name == 'w%s' % n
+        if n > 0:
+            assert name == 'w%s' % n
+        else:
+            assert name == '_w%s' % -n
 
 def test_no_supply_names():
     """

--- a/server/tests/test_ise.py
+++ b/server/tests/test_ise.py
@@ -242,9 +242,9 @@ def test_lookup_goals(app, client, repos_ready):
         ]
 
 @pytest.mark.parametrize('studypath, vers, expected', [
-    ['test.moo.study.expansions', 'v1.0.0', ("special-studypage-test-moo-study-expansions-studyPage-w15_v1-0-0", "target_type", "WIDG")],
-    ['test.moo.bar.results.Pf', 'v2.0.0', ("special-studypage-test-moo-bar-results-Pf-studyPage-w5_v2-0-0", "origin", "test.moo.bar.results.Pf.T@1")],
-    ['test.moo.bar.results.Pf', 'v2.1.0', ("special-studypage-test-moo-bar-results-Pf-studyPage-w13_v2-1-0", "origin", "test.moo.bar.results.Pf.E.A1@2")],
+    ['test.moo.study.expansions', 'v1.0.0', ("special-studypage-test-moo-study-expansions-studyPage-_w14_v1-0-0", "target_type", "WIDG")],
+    ['test.moo.bar.results.Pf', 'v2.0.0', ("special-studypage-test-moo-bar-results-Pf-studyPage-_w4_v2-0-0", "origin", "test.moo.bar.results.Pf.T@1")],
+    ['test.moo.bar.results.Pf', 'v2.1.0', ("special-studypage-test-moo-bar-results-Pf-studyPage-_w12_v2-1-0", "origin", "test.moo.bar.results.Pf.E.A1@2")],
 ])
 def test_load_study_page(app, client, repos_ready, studypath, vers, expected):
     with app.app_context():

--- a/server/tests/test_sphinx.py
+++ b/server/tests/test_sphinx.py
@@ -686,7 +686,7 @@ def test_import_rst_into_pfsc(app):
         d = json.loads(j)
         #print(json.dumps(d, indent=4))
         W = d['widgets']
-        link_w1 = W["test-spx-doc1-anno-Notes-w1_v0-1-0"]
+        link_w1 = W["test-spx-doc1-anno-Notes-_w0_v0-1-0"]
         assert link_w1["type"] == "LINK"
         assert link_w1["ref"] == "test.spx.doc1.foo.pageC._page.w000"
 

--- a/server/tests/test_study_pages.py
+++ b/server/tests/test_study_pages.py
@@ -32,13 +32,13 @@ exp0 = """\
 <h1>Study Notes</h1>
 <hr />
 <h2>Page</h2>
-<p><a class="widget linkWidget special-studypage-test-moo-study-expansions-Notes3-studyPage-w1_v1-0-0" href="#"><code>Notes3</code></a></p>
+<p><a class="widget linkWidget special-studypage-test-moo-study-expansions-Notes3-studyPage-_w0_v1-0-0" href="#"><code>Notes3</code></a></p>
 <h2>Goals</h2>
-<p><span class="widget goalWidget special-studypage-test-moo-study-expansions-Notes3-studyPage-w2_v1-0-0"><span class="graphics"></span></span> <a class="widget linkWidget special-studypage-test-moo-study-expansions-Notes3-studyPage-w3_v1-0-0" href="#"><code>w1</code></a></p>
+<p><span class="widget goalWidget special-studypage-test-moo-study-expansions-Notes3-studyPage-_w1_v1-0-0"><span class="graphics"></span></span> <a class="widget linkWidget special-studypage-test-moo-study-expansions-Notes3-studyPage-_w2_v1-0-0" href="#"><code>w1</code></a></p>
 <p>Some notes on goal w2...</p>
-<p><span class="widget goalWidget special-studypage-test-moo-study-expansions-Notes3-studyPage-w4_v1-0-0"><span class="graphics"></span></span> <a class="widget linkWidget special-studypage-test-moo-study-expansions-Notes3-studyPage-w5_v1-0-0" href="#"><code>w2</code></a></p>
+<p><span class="widget goalWidget special-studypage-test-moo-study-expansions-Notes3-studyPage-_w3_v1-0-0"><span class="graphics"></span></span> <a class="widget linkWidget special-studypage-test-moo-study-expansions-Notes3-studyPage-_w4_v1-0-0" href="#"><code>w2</code></a></p>
 <p>Some notes on goal w2...</p>
-<p><span class="widget goalWidget special-studypage-test-moo-study-expansions-Notes3-studyPage-w6_v1-0-0"><span class="graphics"></span></span> <a class="widget linkWidget special-studypage-test-moo-study-expansions-Notes3-studyPage-w7_v1-0-0" href="#"><code>w3</code></a></p>
+<p><span class="widget goalWidget special-studypage-test-moo-study-expansions-Notes3-studyPage-_w5_v1-0-0"><span class="graphics"></span></span> <a class="widget linkWidget special-studypage-test-moo-study-expansions-Notes3-studyPage-_w6_v1-0-0" href="#"><code>w3</code></a></p>
 <hr />
 """
 
@@ -46,39 +46,39 @@ exp1 = """\
 <h1>Study Notes</h1>
 <hr />
 <h2>Deduction</h2>
-<p><span class="widget goalWidget special-studypage-test-moo-study-expansions-X-studyPage-w1_v1-0-0"><span class="graphics"></span></span> <a class="widget chartWidget special-studypage-test-moo-study-expansions-X-studyPage-w2_v1-0-0" href="#"><code>X</code></a></p>
+<p><span class="widget goalWidget special-studypage-test-moo-study-expansions-X-studyPage-_w0_v1-0-0"><span class="graphics"></span></span> <a class="widget chartWidget special-studypage-test-moo-study-expansions-X-studyPage-_w1_v1-0-0" href="#"><code>X</code></a></p>
 <h2>Goals</h2>
-<p><span class="widget goalWidget special-studypage-test-moo-study-expansions-X-studyPage-w3_v1-0-0"><span class="graphics"></span></span> <a class="widget chartWidget special-studypage-test-moo-study-expansions-X-studyPage-w4_v1-0-0" href="#"><code>A1</code></a></p>
+<p><span class="widget goalWidget special-studypage-test-moo-study-expansions-X-studyPage-_w2_v1-0-0"><span class="graphics"></span></span> <a class="widget chartWidget special-studypage-test-moo-study-expansions-X-studyPage-_w3_v1-0-0" href="#"><code>A1</code></a></p>
 <p>Some notes on node A1...</p>
-<p><span class="widget goalWidget special-studypage-test-moo-study-expansions-X-studyPage-w5_v1-0-0"><span class="graphics"></span></span> <a class="widget chartWidget special-studypage-test-moo-study-expansions-X-studyPage-w6_v1-0-0" href="#"><code>A2</code></a></p>
+<p><span class="widget goalWidget special-studypage-test-moo-study-expansions-X-studyPage-_w4_v1-0-0"><span class="graphics"></span></span> <a class="widget chartWidget special-studypage-test-moo-study-expansions-X-studyPage-_w5_v1-0-0" href="#"><code>A2</code></a></p>
 <hr />
 """
 exp2 = """\
 <h1>Study Notes</h1>
 <hr />
 <h2>Deduction</h2>
-<p><span class="widget goalWidget special-studypage-test-moo-study-expansions-studyPage-w1_v1-0-0"><span class="graphics"></span></span> <a class="widget chartWidget special-studypage-test-moo-study-expansions-studyPage-w2_v1-0-0" href="#"><code>X</code></a></p>
+<p><span class="widget goalWidget special-studypage-test-moo-study-expansions-studyPage-_w0_v1-0-0"><span class="graphics"></span></span> <a class="widget chartWidget special-studypage-test-moo-study-expansions-studyPage-_w1_v1-0-0" href="#"><code>X</code></a></p>
 <h2>Goals</h2>
-<p><span class="widget goalWidget special-studypage-test-moo-study-expansions-studyPage-w3_v1-0-0"><span class="graphics"></span></span> <a class="widget chartWidget special-studypage-test-moo-study-expansions-studyPage-w4_v1-0-0" href="#"><code>A1</code></a></p>
+<p><span class="widget goalWidget special-studypage-test-moo-study-expansions-studyPage-_w2_v1-0-0"><span class="graphics"></span></span> <a class="widget chartWidget special-studypage-test-moo-study-expansions-studyPage-_w3_v1-0-0" href="#"><code>A1</code></a></p>
 <p>Some notes on node A1...</p>
-<p><span class="widget goalWidget special-studypage-test-moo-study-expansions-studyPage-w5_v1-0-0"><span class="graphics"></span></span> <a class="widget chartWidget special-studypage-test-moo-study-expansions-studyPage-w6_v1-0-0" href="#"><code>A2</code></a></p>
+<p><span class="widget goalWidget special-studypage-test-moo-study-expansions-studyPage-_w4_v1-0-0"><span class="graphics"></span></span> <a class="widget chartWidget special-studypage-test-moo-study-expansions-studyPage-_w5_v1-0-0" href="#"><code>A2</code></a></p>
 <hr />
 <h2>Page</h2>
-<p><a class="widget linkWidget special-studypage-test-moo-study-expansions-studyPage-w7_v1-0-0" href="#"><code>Notes1</code></a></p>
+<p><a class="widget linkWidget special-studypage-test-moo-study-expansions-studyPage-_w6_v1-0-0" href="#"><code>Notes1</code></a></p>
 <h2>Goals</h2>
 <hr />
 <h2>Page</h2>
-<p><a class="widget linkWidget special-studypage-test-moo-study-expansions-studyPage-w8_v1-0-0" href="#"><code>Notes2</code></a></p>
+<p><a class="widget linkWidget special-studypage-test-moo-study-expansions-studyPage-_w7_v1-0-0" href="#"><code>Notes2</code></a></p>
 <h2>Goals</h2>
 <hr />
 <h2>Page</h2>
-<p><a class="widget linkWidget special-studypage-test-moo-study-expansions-studyPage-w9_v1-0-0" href="#"><code>Notes3</code></a></p>
+<p><a class="widget linkWidget special-studypage-test-moo-study-expansions-studyPage-_w8_v1-0-0" href="#"><code>Notes3</code></a></p>
 <h2>Goals</h2>
-<p><span class="widget goalWidget special-studypage-test-moo-study-expansions-studyPage-w10_v1-0-0"><span class="graphics"></span></span> <a class="widget linkWidget special-studypage-test-moo-study-expansions-studyPage-w11_v1-0-0" href="#"><code>w1</code></a></p>
+<p><span class="widget goalWidget special-studypage-test-moo-study-expansions-studyPage-_w9_v1-0-0"><span class="graphics"></span></span> <a class="widget linkWidget special-studypage-test-moo-study-expansions-studyPage-_w10_v1-0-0" href="#"><code>w1</code></a></p>
 <p>Some notes on goal w2...</p>
-<p><span class="widget goalWidget special-studypage-test-moo-study-expansions-studyPage-w12_v1-0-0"><span class="graphics"></span></span> <a class="widget linkWidget special-studypage-test-moo-study-expansions-studyPage-w13_v1-0-0" href="#"><code>w2</code></a></p>
+<p><span class="widget goalWidget special-studypage-test-moo-study-expansions-studyPage-_w11_v1-0-0"><span class="graphics"></span></span> <a class="widget linkWidget special-studypage-test-moo-study-expansions-studyPage-_w12_v1-0-0" href="#"><code>w2</code></a></p>
 <p>Some notes on goal w2...</p>
-<p><span class="widget goalWidget special-studypage-test-moo-study-expansions-studyPage-w14_v1-0-0"><span class="graphics"></span></span> <a class="widget linkWidget special-studypage-test-moo-study-expansions-studyPage-w15_v1-0-0" href="#"><code>w3</code></a></p>
+<p><span class="widget goalWidget special-studypage-test-moo-study-expansions-studyPage-_w13_v1-0-0"><span class="graphics"></span></span> <a class="widget linkWidget special-studypage-test-moo-study-expansions-studyPage-_w14_v1-0-0" href="#"><code>w3</code></a></p>
 <hr />
 """
 
@@ -207,7 +207,7 @@ def test_study_page_builder_2(app, repos_ready):
         j = resp["data_json"]
         data = json.loads(j)
         print(json.dumps(data, indent=4))
-        assert data["widgets"]["special-studypage-test-moo-bar-results-Pf-studyPage-w5_v2-0-0"]["origin"] == "test.moo.bar.results.Pf.T@1"
+        assert data["widgets"]["special-studypage-test-moo-bar-results-Pf-studyPage-_w4_v2-0-0"]["origin"] == "test.moo.bar.results.Pf.T@1"
 
 import cProfile, pstats, io
 """

--- a/server/tests/test_widgets.py
+++ b/server/tests/test_widgets.py
@@ -398,3 +398,20 @@ def test_err_in_ctl_default_value(app):
         # The error message should contain information about the ctl widget that
         # set the value.
         assert s.find("Field value was set by ctl widget &#34;_w0&#34; at line 2") > 0
+
+
+@pytest.mark.psm
+def test_goal_widget_missing_name(app):
+    """
+    Show that goal widgets must have an author-supplied name.
+    """
+    with app.app_context():
+        text = """
+        anno Notes @@@
+        Here is <goal:>[a goal widget]{} that we forgot to name.
+        @@@
+        """
+        with pytest.raises(PfscExcep) as ei:
+            mod = build_module_from_text(text, 'test._foo._bar')
+            mod.resolve()
+        assert ei.value.code() == PECode.WIDGET_MISSING_NAME

--- a/server/tests/test_widgets.py
+++ b/server/tests/test_widgets.py
@@ -397,4 +397,4 @@ def test_err_in_ctl_default_value(app):
         s = str(pe)
         # The error message should contain information about the ctl widget that
         # set the value.
-        assert s.find("Field value was set by ctl widget &#34;w1&#34; at line 2") > 0
+        assert s.find("Field value was set by ctl widget &#34;_w0&#34; at line 2") > 0


### PR DESCRIPTION
## Breaking

* Authors are now required to supply names for `goal` widgets.
   
  This is to promote stability of users' checkmarks and study notes, and the ability
  to carry these forward across major version changes, using the move-mapping.


## Fixed

* Auto-generated widget names in annotations now begin with underscore
  (bringing this in line with Sphinx pages).

