### PR TITLE
Repair context menus in Sphinx pages

### DIFF
--- a/changelog.d/skieffer.rst-context-menus.branchnews.fixed.txt
+++ b/changelog.d/skieffer.rst-context-menus.branchnews.fixed.txt
@@ -1,0 +1,2 @@
+Repair context menus in Sphinx pages, so that they load source panels with
+proper `rst` syntax highlighting.

--- a/client/src/content_types/notes/BasePageViewer.js
+++ b/client/src/content_types/notes/BasePageViewer.js
@@ -325,6 +325,7 @@ export class BasePageViewer extends Listenable {
                 version: desc.version,
                 useExisting: true,
                 sourceRow: desc.sourceRow,
+                is_rst: (this.pageType === "SPHINX"),
             };
             this.mgr.hub.contentManager.openContentInActiveTC(info);
         }

--- a/client/src/content_types/source/EditManager.js
+++ b/client/src/content_types/source/EditManager.js
@@ -1042,7 +1042,7 @@ var EditManager = declare(AbstractContentManager, {
      * needed.
      *
      * param info: the info object defining the item to be opened.
-     * param elt: the DOM elmeent where the editor is to be placed.
+     * param elt: the DOM element where the editor is to be placed.
      * param paneId: the id of the ContentPane where this content is being opened.
      *
      * return: promise that resolves when the content is loaded.

--- a/client/src/widgets/Widget.js
+++ b/client/src/widgets/Widget.js
@@ -189,6 +189,7 @@ var Widget = declare(null, {
                 version: this.version,
                 useExisting: true,
                 sourceRow: widget.origInfo.src_line,
+                is_rst: isSphinx,
             };
             cm.addChild(new MenuItem({
                 label: `${this.version === "WIP" ? "Edit" : "View"} Source`,


### PR DESCRIPTION
They were causing source panels to load with pfsc syntax highlighting; now loading with rst highlighting.