### PR TITLE
Repair `chart` widget `select` field

### DIFF
--- a/changelog.d/skieffer.repair-chart-select.branchnews.fixed.txt
+++ b/changelog.d/skieffer.repair-chart-select.branchnews.fixed.txt
@@ -1,0 +1,2 @@
+Repaired issue with chart widget `select` field, where libpath
+was interpreted as `false`.

--- a/server/pfsc/checkinput/__init__.py
+++ b/server/pfsc/checkinput/__init__.py
@@ -21,6 +21,7 @@ from pfsc.excep import PfscExcep, PECode
 from pfsc.checkinput.basic import (
     check_any,
     check_boolean,
+    check_strict_boolean,
     check_integer,
     check_float,
     check_string,
@@ -255,6 +256,7 @@ class IType:
     ANY = 'any'
     DISJ = 'disj'
     BOOLEAN = 'boolean'
+    STRICT_BOOLEAN = 'strict_boolean'
     INTEGER = 'integer'
     FLOAT = 'float'
     SIMPLE_DICT = 'simple_dict'
@@ -290,6 +292,7 @@ TYPE_HANDLERS = {
     IType.ANY: check_any,
     IType.DISJ: check_disjunctive_type,
     IType.BOOLEAN: check_boolean,
+    IType.STRICT_BOOLEAN: check_strict_boolean,
     IType.INTEGER: check_integer,
     IType.FLOAT: check_float,
     IType.SIMPLE_DICT: check_simple_dict,

--- a/server/pfsc/lang/widgets.py
+++ b/server/pfsc/lang/widgets.py
@@ -586,7 +586,7 @@ class CtlWidget(Widget):
                 'spec': {
                     "OPT": {
                         'on': {
-                            'type': IType.BOOLEAN,
+                            'type': IType.STRICT_BOOLEAN,
                             'default_cooked': True,
                         },
                         'topLevel': {
@@ -785,7 +785,7 @@ class ChartWidget(NavWidget):
                     'type': IType.DISJ,
                     'alts': [
                         {
-                            'type': IType.BOOLEAN,
+                            'type': IType.STRICT_BOOLEAN,
                         },
                         {
                             'type': IType.RELBOXLISTING,
@@ -807,10 +807,10 @@ class ChartWidget(NavWidget):
                     ]
                 },
                 'transition': {
-                    'type': IType.BOOLEAN
+                    'type': IType.STRICT_BOOLEAN
                 },
                 'flow': {
-                    'type': IType.BOOLEAN
+                    'type': IType.STRICT_BOOLEAN
                 },
                 'viewOpts': {
                     'type': IType.DICT,
@@ -847,7 +847,7 @@ class ChartWidget(NavWidget):
                                 ],
                             },
                             'insetAware': {
-                                'type': IType.BOOLEAN,
+                                'type': IType.STRICT_BOOLEAN,
                             },
                         }
                     }

--- a/server/tests/test_widgets.py
+++ b/server/tests/test_widgets.py
@@ -415,3 +415,35 @@ def test_goal_widget_missing_name(app):
             mod = build_module_from_text(text, 'test._foo._bar')
             mod.resolve()
         assert ei.value.code() == PECode.WIDGET_MISSING_NAME
+
+
+@pytest.mark.psm
+@pytest.mark.parametrize("raw_select_val, final_select_val", [
+    ['true', True],
+    ['false', False],
+    ['Thm.C', ['test._foo._bar.Thm.C']],
+    ['"Thm.C"', ['test._foo._bar.Thm.C']],
+])
+def test_chart_widget_select_field(app, raw_select_val, final_select_val):
+    """
+    Check that different values passed to the 'select' field in a chart widget
+    are processed correctly.
+    """
+    with app.app_context():
+        text = """
+        deduc Thm {
+            asrt C { sy = "C" }
+            meson = "C"
+        }
+        
+        anno Notes @@@
+        Here is <chart:w0>[a chart widget]{
+            select: %s
+        } that we forgot to name.
+        @@@
+        """ % raw_select_val
+        mod = build_module_from_text(text, 'test._foo._bar')
+        mod.resolve()
+        w = mod.get('Notes').widget_lookup['w0']
+        sel = w.data['select']
+        assert sel == final_select_val


### PR DESCRIPTION
## Fixed

Repaired issue with chart widget `select` field, where libpath
was interpreted as `false`.