### PR TITLE
Halt Sphinx build only on selected warnings

### DIFF
--- a/server/pfsc/build/__init__.py
+++ b/server/pfsc/build/__init__.py
@@ -94,7 +94,7 @@ import pfsc.constants
 def build_repo(
         target, version=pfsc.constants.WIP_TAG,
         verbose=False, progress=None,
-        make_clean=False
+        make_clean=False, quiet=False
 ):
     """
     Build a Proofscape repo.
@@ -106,6 +106,7 @@ def build_repo(
         integer 2 in order to add performance output.
     :param progress: as for the Builder class.
     :param make_clean: as for the Builder class.
+    :param quiet: set True to silence certain diagnostic output.
 
     :return: the Builder instance that performed the build.
     """
@@ -113,7 +114,7 @@ def build_repo(
         b = Builder(
             target, version=version,
             verbose=verbose, progress=progress,
-            make_clean=make_clean
+            make_clean=make_clean, quiet=quiet
         )
     else:
         b = target
@@ -377,6 +378,7 @@ class Builder:
             self, libpath, version=pfsc.constants.WIP_TAG,
             verbose=False, progress=None,
             make_clean=False, current_builds=None,
+            quiet=False,
     ):
         """
         :param libpath: libpath pointing at or into the repo to be built.
@@ -389,6 +391,7 @@ class Builder:
             with Sphinx (if a part of the build), all before beginning this build
         :param current_builds: serves to catch cyclic build errors.
             See `load_module()` function.
+        :param quiet: set True to silence certain diagnostic output
         """
         self.repo_info = get_repo_info(libpath)
         self.repopath = self.repo_info.libpath
@@ -398,6 +401,7 @@ class Builder:
         self.monitor = BuildMonitor(progress)
         self.graph_writer = get_graph_writer()
         self.build_in_gdb = building_in_gdb()
+        self.quiet = quiet
 
         if current_builds is None:
             current_builds = set()
@@ -863,7 +867,8 @@ class Builder:
                 app.set_html_assets_policy('always')
                 app.build(force_all=force_all, filenames=filenames)
         except (SphinxError, Exception) as e:
-            traceback.print_exc()
+            if not self.quiet:
+                traceback.print_exc()
             oe = getattr(e, 'orig_exc', None)
             if isinstance(oe, PfscExcep):
                 raise oe

--- a/server/pfsc/build/__init__.py
+++ b/server/pfsc/build/__init__.py
@@ -852,9 +852,14 @@ class Builder:
         buildername = 'dummy' if just_read_no_write else 'html'
         try:
             with patch_docutils(confdir), docutils_namespace():
+                # We keep `warningiserror=False` in our Sphinx app, since many warnings
+                # (e.g. "document not in toctree") really should not halt the build process.
+                # However, our Sphinx extension monkey patches Sphinx's `WarningIsErrorFilter`,
+                # so that it's possible for us to make special warnings that *do* get raised
+                # as exceptions.
                 app = Sphinx(sourcedir, confdir, outputdir, doctreedir,
                              buildername, confoverrides=confoverrides,
-                             warningiserror=True)
+                             warningiserror=False)
                 app.connect('env-before-read-docs', set_builder_in_environment)
                 app.connect('env-before-read-docs', add_and_record_rereads)
                 app.connect('env-updated', env_updated_handler)

--- a/server/pfsc/constants.py
+++ b/server/pfsc/constants.py
@@ -138,6 +138,10 @@ PROHIBITED_RST_DOCNAMES = [
     'genindex', 'search',
 ]
 
+# Presence of this string in error messages is used to mark Sphinx warnings
+# as meriting immediate halt of the build process.
+PFSC_SPHINX_CRIT_ERR_MARKER = 'PROOFSCAPE-SPHINX-ERROR'
+
 
 class ContentDescriptorType:
     """

--- a/server/pfsc/sphinx/__init__.py
+++ b/server/pfsc/sphinx/__init__.py
@@ -30,6 +30,9 @@ from pfsc.sphinx.embed import PfscEmbedDirective
 from pfsc.sphinx.links import ExternalLinks
 from pfsc.sphinx.vertex import VerTeX2TeX
 
+# This import achieves a monkey patch:
+import pfsc.sphinx.errors
+
 
 def setup(app):
     app.add_config_value('pfsc_repopath', None, 'html')

--- a/server/pfsc/sphinx/errors.py
+++ b/server/pfsc/sphinx/errors.py
@@ -1,0 +1,67 @@
+# --------------------------------------------------------------------------- #
+#   Copyright (c) 2011-2024 Proofscape Contributors                           #
+#                                                                             #
+#   Licensed under the Apache License, Version 2.0 (the "License");           #
+#   you may not use this file except in compliance with the License.          #
+#   You may obtain a copy of the License at                                   #
+#                                                                             #
+#       http://www.apache.org/licenses/LICENSE-2.0                            #
+#                                                                             #
+#   Unless required by applicable law or agreed to in writing, software       #
+#   distributed under the License is distributed on an "AS IS" BASIS,         #
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  #
+#   See the License for the specific language governing permissions and       #
+#   limitations under the License.                                            #
+# --------------------------------------------------------------------------- #
+
+import sphinx.util.logging
+
+from pfsc.constants import PFSC_SPHINX_CRIT_ERR_MARKER
+
+
+class ProofscapeWarningIsErrorFilter(sphinx.util.logging.WarningIsErrorFilter):
+    """
+    It can be tricky to halt the Sphinx build, with a helpful error message describing
+    the location (filename and line number) where the error occurred. This class gives
+    us a way to do that.
+
+    Sphinx & docutils offer nice, built-in mechanisms for producing a *warning* with the
+    location, but warnings do not halt the build.
+
+    Alternatively, when you form your Sphinx app, you can set `warningiserror=True`, but
+    then *every* warning stops the build, which is far too much:
+
+        Example 1: "document not in toctree" warning halts build!
+
+        Example 2: If you rename a directory in your Proofscape repo at the CLI, after having
+        built at least once, then you will get a "toctree contains reference to nonexisting
+        document" error, and you will not be able to build, even if building clean, no matter
+        what you do.
+
+    So `warningiserror=True` is much too strong, and we need a different solution.
+
+    Here we subclass Sphinx's `WarningIsErrorFilter` class, which is the one responsible
+    for turning warnings into errors when `warningiserror=True`. For this to make any
+    difference, however, we have to monkey patch it into place, *replacing* the built-in
+    class with this one, before we form our `Sphinx` instance. The patch is performed at
+    the bottom of this module, so importing this into our Sphinx extension is enough.
+
+    When we form our `Sphinx` instance, we set ``warningiserror=False`; however, our
+    custom filter looks for a special substring, the value of `PFSC_SPHINX_CRIT_ERR_MARKER`,
+    in the warning message. When that is present, then we ensure that the warning *is* raised
+    as a build-halting exception.
+    """
+
+    def filter(self, record):
+        if record.msg.find(PFSC_SPHINX_CRIT_ERR_MARKER) >= 0:
+            # Since we're about to cause an exception to be raised, it doesn't matter
+            # if we permanently alter the Sphinx app's `warningiserror` setting.
+            # That app instance is not going to do anything more anyway.
+            self.app.warningiserror = True
+            # Ensure we don't get skipped:
+            record.skip_warningsiserror = False
+        return super().filter(record)
+
+
+# Monkey patch it into place:
+sphinx.util.logging.WarningIsErrorFilter = ProofscapeWarningIsErrorFilter

--- a/server/pfsc/sphinx/widgets/__init__.py
+++ b/server/pfsc/sphinx/widgets/__init__.py
@@ -20,6 +20,7 @@ from lark.exceptions import LarkError
 
 from pfsc.checkinput import extract_full_key_set
 from pfsc.lang.freestrings import build_pfsc_json
+from pfsc.constants import PFSC_SPHINX_CRIT_ERR_MARKER
 
 from .base import (
     pfsc_block_widget, pfsc_inline_widget,
@@ -51,21 +52,23 @@ def generic_data_field_converter(text):
     directives.
 
     This is applied by `docutils`, so we need to raise its `ExtensionOptionError`
-    in case of any parsing problems, in order to get an informative error message.
+    in case of any parsing problems, in order to get an informative error message,
+    including the location (filename and lineno) where the error occurred.
 
     Note: This only results in a "warning" as Sphinx sees it, so, for the build
     to actually be interrupted and the user to see an error message through PISE,
-    we have to set `warningiserror=True` when we form our `Sphinx` app instance
-    in the pfsc `Builder`.
+    we have to add the `PFSC_SPHINX_CRIT_ERR_MARKER` to the error message.
 
     See also:
+        pfsc.sphinx.errors.ProofscapeWarningIsErrorFilter
         pfsc.build.Builder.build_sphinx_doc()
         docutils.parsers.rst.states.Body.parse_extension_options()
     """
     try:
         pf_json = build_pfsc_json(text)
     except LarkError as e:
-        raise ExtensionOptionError(f'Error parsing PF-JSON: {e}')
+        msg = f'{PFSC_SPHINX_CRIT_ERR_MARKER}: Error parsing PF-JSON: {e}'
+        raise ExtensionOptionError(msg)
     return pf_json
 
 

--- a/server/pfsc/sphinx/widgets/nav_widgets.py
+++ b/server/pfsc/sphinx/widgets/nav_widgets.py
@@ -19,6 +19,7 @@ import re
 from lark.exceptions import LarkError
 from sphinx.util.docutils import SphinxRole
 
+from pfsc.constants import PFSC_SPHINX_CRIT_ERR_MARKER
 from pfsc.lang.freestrings import build_pfsc_json
 from pfsc.lang.widgets import WIDGET_TYPE_TO_CLASS
 from pfsc.sphinx.widgets.base import finish_run
@@ -51,6 +52,9 @@ class PfscNavWidgetRole(SphinxRole):
         return name
 
     def write_error_return_values(self, msg_text):
+        # Adding `PFSC_SPHINX_CRIT_ERR_MARKER` makes it so we halt the build,
+        # instead of simply logging a warning:
+        msg_text = f'{PFSC_SPHINX_CRIT_ERR_MARKER}: {msg_text}'
         msg = self.inliner.reporter.error(msg_text, line=self.lineno)
         prb = self.inliner.problematic(self.rawtext, self.rawtext, msg)
         return [prb], [msg]

--- a/server/tests/resources/repo/spx/err/v0.1.0/conf.py
+++ b/server/tests/resources/repo/spx/err/v0.1.0/conf.py
@@ -1,0 +1,29 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../..'))
+
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'sphinx-proofscape doc with errors'
+copyright = '2024, author'
+author = 'author'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = []
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'venv']
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+#html_theme = 'alabaster'
+#html_static_path = ['_static']

--- a/server/tests/resources/repo/spx/err/v0.1.0/index.rst
+++ b/server/tests/resources/repo/spx/err/v0.1.0/index.rst
@@ -1,0 +1,28 @@
+sphinx-proofscape doc with errors
+=================================
+
+.. pfsc::
+
+    deduc Thm {
+        asrt C {
+            sy="C"
+        }
+        meson = "C"
+    }
+
+    deduc Pf of Thm.C {
+        asrt R {
+            sy="R"
+        }
+        asrt S {
+            sy="S"
+        }
+        meson = "R, so S, therefore Thm.C."
+    }
+
+
+This chart widget has an error, because the ``view`` field wants to list
+a libpath and a multipath, but it fails to put quotation marks around this.
+
+.. pfsc-chart::
+    :view: Thm.C, Pf.{R,S}

--- a/server/tests/resources/repo/spx/err/v0.2.0/conf.py
+++ b/server/tests/resources/repo/spx/err/v0.2.0/conf.py
@@ -1,0 +1,29 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../..'))
+
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'sphinx-proofscape doc with errors'
+copyright = '2024, author'
+author = 'author'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = []
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'venv']
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+#html_theme = 'alabaster'
+#html_static_path = ['_static']

--- a/server/tests/resources/repo/spx/err/v0.2.0/index.rst
+++ b/server/tests/resources/repo/spx/err/v0.2.0/index.rst
@@ -1,0 +1,26 @@
+sphinx-proofscape doc with errors
+=================================
+
+.. pfsc::
+
+    deduc Thm {
+        asrt C {
+            sy="C"
+        }
+        meson = "C"
+    }
+
+    deduc Pf of Thm.C {
+        asrt R {
+            sy="R"
+        }
+        asrt S {
+            sy="S"
+        }
+        meson = "R, so S, therefore Thm.C."
+    }
+
+This time we have an error in a chart widget written in *role* form.
+The SUBTEXT is okay, but we put the ROLE_FIELD in parentheses, instead
+of angle brackets:
+:pfsc-chart:`label and (target)`

--- a/server/tests/util/__init__.py
+++ b/server/tests/util/__init__.py
@@ -181,6 +181,7 @@ def get_basic_repos():
         lambda repo: not (
             repo.libpath.startswith('test.foo.') or
             repo.libpath.startswith('test.moo.err') or
+            repo.libpath.startswith('test.spx.err') or
             repo.libpath in [
                 #'test.hist.lit',
             ]


### PR DESCRIPTION
We provide a new mechanism, so that warnings logged while processing
pfsc widgets in Sphinx pages are raised as exceptions, while other ordinary
Sphinx warnings are not.