### PR TITLE
Catch prohibited names

### DIFF
--- a/changelog.d/skieffer.catch-prohib-names.branchnews.fixed.txt
+++ b/changelog.d/skieffer.catch-prohib-names.branchnews.fixed.txt
@@ -1,0 +1,2 @@
+Raise exception if user supplies entity with prohibited name
+(`true`, `false`, or `null`).

--- a/server/pfsc/lang/annotations.py
+++ b/server/pfsc/lang/annotations.py
@@ -84,6 +84,10 @@ class Annotation(EnrichmentPage):
         EnrichmentPage.resolve(self)
 
     @property
+    def user_supplied_name(self):
+        return not self.libpath.startswith('special.')
+
+    @property
     def trusted(self):
         if self._trusted is None:
             assert (libpath := self.getLibpath()) is not None
@@ -92,6 +96,9 @@ class Annotation(EnrichmentPage):
 
     def getFirstRowNum(self):
         return None if self.textRange is None else self.textRange[0]
+
+    def get_lineno_within_module(self):
+        return self.getFirstRowNum()
 
     def get_index_type(self):
         return IndexType.ANNO

--- a/server/pfsc/lang/deductions.py
+++ b/server/pfsc/lang/deductions.py
@@ -168,6 +168,10 @@ class Deduction(Enrichment, NodeLikeObj):
         self.target_paths = target_paths
         self.pending_clones = deque()
 
+    @property
+    def user_supplied_name(self):
+        return not self.libpath.startswith('special.')
+
     def resolve(self):
         """
         RESOLUTION steps that are delayed so that we can have a pure READ phase,
@@ -228,6 +232,9 @@ class Deduction(Enrichment, NodeLikeObj):
 
     def getFirstRowNum(self):
         return None if self.textRange is None else self.textRange[0]
+
+    def get_lineno_within_module(self):
+        return self.getFirstRowNum()
 
     def get_index_type(self):
         return IndexType.DEDUC
@@ -927,6 +934,16 @@ class Node(NodeLikeObj):
         self.name = name
         self.subnodeSeq = []
         self.docReference = None
+
+    @property
+    def user_supplied_name(self):
+        # dummy nodes get names like `_pre` and `_post`.
+        # As for QSTN and UCON nodes, their names *are* user-supplied, in the sense that
+        # users write them in meson scripts; however, this `user_supplied_name` property
+        # is designed to serve a test that names are acceptable, and if we return `True`
+        # then they will be required not to begin with `?` or `!`. So, it's a bit hacky,
+        # but for now it's what we're doing.
+        return self.nodeType not in ['dummy', NodeType.QSTN, NodeType.UCON]
 
     def add_as_content(self, owner):
         owner.addNode(self)

--- a/server/pfsc/lang/widgets.py
+++ b/server/pfsc/lang/widgets.py
@@ -174,6 +174,13 @@ class Widget(PfscObj):
         self.keep_relative = []
 
     @property
+    def user_supplied_name(self):
+        # For widgets, there is checking at defn time that user-supplied names not begin
+        # with underscore. And system-generated ones always *do* begin with underscore.
+        # So we can simply use that as the test here.
+        return not self.name.startswith("_")
+
+    @property
     def lineno(self):
         return self.lineno_within_anno
 

--- a/server/pfsc/sphinx/pages.py
+++ b/server/pfsc/sphinx/pages.py
@@ -52,6 +52,10 @@ class SphinxPage(EnrichmentPage):
         self.name = FIXED_PAGE_NAME
         self.widgets = []
 
+    @property
+    def user_supplied_name(self):
+        return False
+
     def get_index_type(self):
         return pfsc.constants.IndexType.SPHINX
 


### PR DESCRIPTION
Raise exception if author supplies entity with prohibited name in set `{"true", "false", "null"}`.