### PR TITLE
Make `max-width` setting for `Hub.alert()` more selective

### DIFF
--- a/client/src/Hub.js
+++ b/client/src/Hub.js
@@ -1269,7 +1269,14 @@ var Hub = declare(null, {
     alert: function({title, content}) {
         title = title || 'Info';
         content = content || '(nothing here)';
-        content = `<div class="padded20 mw48">${content}</div>`;
+
+        let classes = "padded20";
+        // Set a max width, for error alerts:
+        if (title === "Error") {
+            classes += " mw48";
+        }
+
+        content = `<div class="${classes}">${content}</div>`;
         const dlg = new Dialog({
             title: title,
             content: content,


### PR DESCRIPTION
Now applying this only to error alerts. Otherwise, it can easily break some other dialogs, including at least the "About" dialog.