### PR TITLE
c: Repair `Widget.groupId`

### DIFF
--- a/client/src/content_types/notes/NotesManager.js
+++ b/client/src/content_types/notes/NotesManager.js
@@ -343,7 +343,7 @@ var NotesManager = declare(AbstractContentManager, {
      */
     groupHasRepresentative: function(groupId) {
         for (let [uid, widget] of this.widgets) {
-            if (widget.groupId === groupId) {
+            if (widget.groupId() === groupId) {
                 return true;
             }
         }
@@ -909,7 +909,7 @@ var NotesManager = declare(AbstractContentManager, {
         const LN = this.linkingMap;
 
         const widget = this.widgets.get(uid);
-        const gid = widget.groupId;
+        const gid = widget.groupId();
 
         const cm = this.hub.contentManager;
         const clickedPane = pane;

--- a/client/src/content_types/notes/SphinxViewer.js
+++ b/client/src/content_types/notes/SphinxViewer.js
@@ -287,6 +287,13 @@ export class SphinxViewer extends BasePageViewer {
             loc.scrollFrac = current.scrollFrac;
             loc.scrollSel = current.scrollSel;
         }
+        // By passing a location with a `url`, but without a `libpath` (or `version`),
+        // we can force a reload for pages that are already loaded. This will happen
+        // because, when control reaches our `pageContentsUpdateStep()` method, it will
+        // call `this.describeLocationUpdate()`, which will call it a "page change" on
+        // the grounds that the new location has a different `libpath` (namely none).
+        // In cases viewed as "page change," our `pageContentsUpdateStep()` method goes
+        // on to (re)load the iframe.
         await super.reloadPage(loc);
     }
 

--- a/client/src/widgets/ChartWidget.js
+++ b/client/src/widgets/ChartWidget.js
@@ -57,14 +57,14 @@ const ChartWidget = declare(NavWidget, {
             const over = info.hoverColor.over,
                 out  = info.hoverColor.out;
             wdq.on('mouseover', async () => {
-                const targetUuids = await nm.linkingMap.get(info.uuid, this.groupId);
+                const targetUuids = await nm.linkingMap.get(info.uuid, this.groupId());
                 for (const targetUuid of targetUuids) {
                     this.hub.contentManager.updateContentAnywhereByUuid(
                         {type: "CHART", color: over}, targetUuid, { selectPane: true });
                 }
             });
             wdq.on('mouseout', async () => {
-                const targetUuids = await nm.linkingMap.get(info.uuid, this.groupId);
+                const targetUuids = await nm.linkingMap.get(info.uuid, this.groupId());
                 for (const targetUuid of targetUuids) {
                     this.hub.contentManager.updateContentAnywhereByUuid(
                         {type: "CHART", color: out}, targetUuid, { selectPane: true });

--- a/client/src/widgets/Widget.js
+++ b/client/src/widgets/Widget.js
@@ -46,8 +46,6 @@ var Widget = declare(null, {
     uid: null,
     // the libpath of the page to which this widget belongs:
     pagepath: null,
-    // the ID of the "widget group" (or "pane group") to which this widget belongs, if any:
-    groupId: null,
     // the info object as originally passed:
     origInfo: null,
     // a "live" info object: starts as a copy of the one originally passed;
@@ -68,11 +66,15 @@ var Widget = declare(null, {
         this.uid = info.uid;
         this.pagepath = libpath.slice(0, libpath.lastIndexOf('.'));
         this.modpath = libpath.slice(0, this.pagepath.lastIndexOf('.'));
-        this.groupId = info.pane_group;
         this.origInfo = info;
         this.liveInfo = this.getInfoCopy();
         this.contextMenuByPaneId = new Map();
         this.listeners = {};
+    },
+
+    // the ID of the "widget group" (or "pane group") to which this widget belongs, if any:
+    groupId: function() {
+        return this.origInfo?.pane_group;
     },
 
     getPagepathv: function() {


### PR DESCRIPTION
The `groupId` property of a widget was not getting updated when a page was rebuilt/reloaded.

This is because it was read once out of the widget info at construction time, and never again.

We now use a method, instead of a property, for `groupId`.

Note: Tried to use a proper `get` method, but `Widget` is still a Dojo-style class, which seems not to support this.