### PR TITLE
Rework param widget fields

### DIFF
--- a/changelog.d/skieffer.rework-param-widgets.branchnews.changed.txt
+++ b/changelog.d/skieffer.rework-param-widgets.branchnews.changed.txt
@@ -1,0 +1,2 @@
+In `param` widgets, `tex` field is now required, and `name` field is
+no longer accepted.

--- a/client/other-versions.json
+++ b/client/other-versions.json
@@ -1,7 +1,7 @@
 {
   "pfsc-pdf": "3.2.0",
   "pyodide": "0.21.0",
-  "pfsc-examp": "0.23.0",
+  "pfsc-examp": "0.24.0",
   "pfsc-util": "0.22.8",
   "displaylang": "0.23.0",
   "displaylang-sympy": "0.10.4",

--- a/server/pfsc/lang/widgets.py
+++ b/server/pfsc/lang/widgets.py
@@ -1590,16 +1590,13 @@ class ParamWidget(ExampWidget):
                 'ptype': {
                     'type': IType.STR,
                 },
-                'name': {
+                'tex': {
                     'type': IType.STR,
                 },
             },
             "OPT": {
                 'init': {
                     'type': IType.ANY,
-                },
-                'tex': {
-                    'type': IType.STR,
                 },
                 'descrip': {
                     'type': IType.STR,

--- a/server/req/test-requirements.hashless
+++ b/server/req/test-requirements.hashless
@@ -7,4 +7,4 @@
 #-e ../displaylang
 #-e ../sympy
 
-git+https://github.com/proofscape/pfsc-test-modules.git@v0.30.0a2
+git+https://github.com/proofscape/pfsc-test-modules.git@v0.30.0a3

--- a/server/req/test-requirements.in
+++ b/server/req/test-requirements.in
@@ -13,4 +13,4 @@ pytest-cov==4.0.0
 # is instead delivered to the user's browser via Pyodide) we do have unit
 # tests here in pfsc-server that help test code living in the pfsc-examp
 # project. So for testing we do install it.
-pfsc-examp==0.23.0
+pfsc-examp==0.24.0

--- a/server/req/test-requirements.txt
+++ b/server/req/test-requirements.txt
@@ -165,9 +165,9 @@ packaging==23.1 \
     # via
     #   -c requirements.txt
     #   pytest
-pfsc-examp==0.23.0 \
-    --hash=sha256:1ab6bbfb06e24f27204ed90b3128a592dc203857161f5c3863d562c95b2342f8 \
-    --hash=sha256:a5cbd531f0690111c16739063aaf1b04b2c6b30c9a95cb56f4b4d7b6a6254786
+pfsc-examp==0.24.0 \
+    --hash=sha256:3020a680a7565e66f21721c9f9024ac0c7a1dc3bb339348126c0194d3ada8be7 \
+    --hash=sha256:90aa09d8c1fb63f8c9fb8c83ae96488d5365081dd97732df469158bad2500830
     # via -r test-requirements.in
 pfsc-util==0.22.8 \
     --hash=sha256:2967e36233fc05b303257d1639317e9d8db3e50f8054cc5f48b8da6dd36042a0 \

--- a/server/tests/resources/repo/foo/bar/v13/expansions.pfsc
+++ b/server/tests/resources/repo/foo/bar/v13/expansions.pfsc
@@ -112,7 +112,7 @@ untrusted.
 
 <param:eg1_k>[]{
     ptype: "NumberField",
-    name: "k",
+    tex: "k",
     init: "cyc(7)",
 }
 

--- a/server/tests/resources/repo/foo/eg/v0/notes.pfsc
+++ b/server/tests/resources/repo/foo/eg/v0/notes.pfsc
@@ -4,7 +4,7 @@ Cyclic dependency between param widgets?
 
 <param:eg1_f>[]{
     ptype: "Foo",
-    name: "f",
+    tex: "f",
     import: {
         b: eg1_b,
     },
@@ -12,7 +12,7 @@ Cyclic dependency between param widgets?
 
 <param:eg1_b>[]{
     ptype: "Bar",
-    name: "b",
+    tex: "b",
     import: {
         f: eg1_f,
     },
@@ -29,12 +29,12 @@ This time both widgets should build.
 
 <param:eg1_f>[]{
     ptype: "Prime",
-    name: "f",
+    tex: "f",
 }
 
 <param:eg1_b>[]{
     ptype: "Prime",
-    name: "b",
+    tex: "b",
     import: {
         f: eg1_f,
     },

--- a/server/tests/resources/repo/foo/eg/v2/notes.pfsc
+++ b/server/tests/resources/repo/foo/eg/v2/notes.pfsc
@@ -2,7 +2,7 @@ anno Notes @@@
 
 <param:eg1_n>[]{
     ptype: "Integer",
-    name: "n",
+    tex: "n",
     init: 12,
     args: {
         gt: 5,
@@ -11,7 +11,6 @@ anno Notes @@@
 
 <param:eg1_d1>[]{
     ptype: "Divisor",
-    name: "d1",
     tex: "d_1",
     init: 3,
     import: {
@@ -21,7 +20,6 @@ anno Notes @@@
 
 <param:eg1_d2>[]{
     ptype: "Divisor",
-    name: "d2",
     tex: "d_2",
     args: {
         dividing: 18,
@@ -31,7 +29,6 @@ anno Notes @@@
 
 <param:eg1_d3>[]{
     ptype: "Divisor",
-    name: "d3",
     tex: "d_3",
     import: {
         n: eg1_n,
@@ -43,19 +40,18 @@ anno Notes @@@
 
 <param:eg1_p1>[]{
     ptype: "Prime",
-    name: "p1",
     tex: "p_1",
     init: 11,
 }
 
 <param:eg1_p2>[]{
     ptype: "Prime",
-    name: "p2",
+    tex: "p_2",
 }
 
 <param:eg1_p3>[]{
     ptype: "Prime",
-    name: "p3",
+    tex: "p_3",
     args: {
         odd: true,
     }
@@ -63,7 +59,7 @@ anno Notes @@@
 
 <param:eg1_p4>[]{
     ptype: "Prime",
-    name: "p4",
+    tex: "p_4",
     init: 13,
     args: {
         chooser_upper_bound: 71,
@@ -72,7 +68,7 @@ anno Notes @@@
 
 <param:eg1_p5>[]{
     ptype: "Prime",
-    name: "p5",
+    tex: "p_5",
     init: 17,
     args: {
         chooser_upper_bound: 163,
@@ -81,7 +77,7 @@ anno Notes @@@
 
 <param:eg1_p6>[]{
     ptype: "Prime",
-    name: "p6",
+    tex: "p_6",
     init: 101,
     args: {
         chooser_upper_bound: 163,
@@ -90,7 +86,7 @@ anno Notes @@@
 
 <param:eg1_p7>[]{
     ptype: "Prime",
-    name: "p7",
+    tex: "p_7",
     init: 23,
     import: {
         n: eg1_n,
@@ -102,7 +98,7 @@ anno Notes @@@
 
 <param:eg1_r1>[]{
     ptype: "PrimRes",
-    name: "r1",
+    tex: "r_1",
     args: {
         m: 49,
     }
@@ -110,7 +106,7 @@ anno Notes @@@
 
 <param:eg1_r2>[]{
     ptype: "PrimRes",
-    name: "r2",
+    tex: "r_2",
     args: {
         m: 343,
     }
@@ -118,7 +114,7 @@ anno Notes @@@
 
 <param:eg1_r3>[]{
     ptype: "PrimRes",
-    name: "r3",
+    tex: "r_3",
     args: {
         m: 2401,
     }
@@ -126,7 +122,7 @@ anno Notes @@@
 
 <param:eg1_r4>[]{
     ptype: "PrimRes",
-    name: "r4",
+    tex: "r_4",
     import: {
         p1: eg1_p1,
     },
@@ -137,7 +133,7 @@ anno Notes @@@
 
 <param:eg1_K1>[]{
     ptype: "NumberField",
-    name: "K1",
+    tex: "K_1",
     init: "cyc(7)",
     args: {
         gen: "zeta",
@@ -146,7 +142,7 @@ anno Notes @@@
 
 <param:eg1_K2>[]{
     ptype: "NumberField",
-    name: "K2",
+    tex: "K_2",
     init: "cyclotomic_poly(7)",
     args: {
         gen: "zeta",
@@ -155,7 +151,7 @@ anno Notes @@@
 
 <param:eg1_K3>[]{
     ptype: "NumberField",
-    name: "K3",
+    tex: "K_3",
     init: "x^2 + 5",
     args: {
         gen: "alpha",
@@ -165,7 +161,7 @@ anno Notes @@@
 
 <param:eg1_K4>[]{
     ptype: "NumberField",
-    name: "K4",
+    tex: "K_4",
     init: "y^3 + 4*y - 7",
     args: {
         var: "u",
@@ -174,7 +170,6 @@ anno Notes @@@
 
 <param:eg1_P1>[]{
     ptype: "PrimeIdeal",
-    name: "P1",
     tex: "\mathfrak{p}_1",
     import: {
         k: eg1_K1,
@@ -186,7 +181,6 @@ anno Notes @@@
 
 <param:eg1_P2>[]{
     ptype: "PrimeIdeal",
-    name: "P2",
     tex: "\mathfrak{p}_2",
     init: 2,
     import: {

--- a/server/tests/resources/repo/foo/eg/v2/notes.pfsc
+++ b/server/tests/resources/repo/foo/eg/v2/notes.pfsc
@@ -62,7 +62,7 @@ anno Notes @@@
     tex: "p_4",
     init: 13,
     args: {
-        chooser_upper_bound: 71,
+        chooserUpperBound: 71,
     }
 }
 
@@ -71,7 +71,7 @@ anno Notes @@@
     tex: "p_5",
     init: 17,
     args: {
-        chooser_upper_bound: 163,
+        chooserUpperBound: 163,
     }
 }
 
@@ -80,7 +80,7 @@ anno Notes @@@
     tex: "p_6",
     init: 101,
     args: {
-        chooser_upper_bound: 163,
+        chooserUpperBound: 163,
     }
 }
 
@@ -92,7 +92,7 @@ anno Notes @@@
         n: eg1_n,
     },
     args: {
-        chooser_upper_bound: "n + 100",
+        chooserUpperBound: "n + 100",
     }
 }
 

--- a/server/tests/resources/repo/foo/eg/v3/notes.pfsc
+++ b/server/tests/resources/repo/foo/eg/v3/notes.pfsc
@@ -2,7 +2,6 @@ anno Notes @@@
 
 <param:eg1_theta>[]{
     ptype: "Integer",
-    name: "theta",
     tex: "n",
     init: 12,
     args: {
@@ -15,7 +14,7 @@ this divisor shall divide the integer `theta`.
 
 <param:eg1_d>[]{
     ptype: "Divisor",
-    name: "d",
+    tex: "d",
     init: 3,
     import: {
         theta: eg1_theta,
@@ -31,7 +30,7 @@ the parameter widget `theta`, and does not import it.
 
 <param:eg1_K>[]{
     ptype: "NumberField",
-    name: "K",
+    tex: "K",
     init: "x^2 + 5",
     args: {
         gen: "theta",

--- a/server/tests/resources/repo/spx/doc1/v0.1.0/foo/pageE.rst
+++ b/server/tests/resources/repo/spx/doc1/v0.1.0/foo/pageE.rst
@@ -14,7 +14,7 @@ Examp Widgets
 
 .. pfsc-param:: eg1_k:
     :ptype: "NumberField"
-    :name: "k"
+    :tex: "k"
     :init: "cyc(7)"
     :args: {
         gen: "zeta",

--- a/server/tests/test_sphinx.py
+++ b/server/tests/test_sphinx.py
@@ -618,7 +618,7 @@ PAGE_E_PAGE_DATA = {
     "widgets": {
         "test-spx-doc1-foo-pageE-_page-eg1_k_v0-1-0": {
             "ptype": "NumberField",
-            "name": "k",
+            "tex": "k",
             "default": "cyc(7)",
             "args": {
                 "gen": "zeta",


### PR DESCRIPTION
The `name` field for `param` widgets was a holdover from server-side re-eval of examp widgets, when HTML form elements were used, and had to have names. So this can now be eliminated. But then `tex` can no longer default to `name`, so becomes a required field.

## Breaking

* In `param` widgets, `tex` field is now required, and `name` field is no longer accepted.