### PR TITLE
Ensure correct syntax highlighting on reload of editor panel

### DIFF
--- a/client/src/content_types/source/EditManager.js
+++ b/client/src/content_types/source/EditManager.js
@@ -273,6 +273,7 @@ var EditManager = declare(AbstractContentManager, {
             firstVisibleRow : editor.getFirstVisibleRow(),
             cursorPos       : editor.getCursorPosition(),
             sidebar         : this.getSidebarProperties(editor),
+            is_rst          : editor.getSession().getMode().$id.endsWith('/rst'),
         };
     },
 


### PR DESCRIPTION
We now include an `is_rst` property in the state description for editor panels, so that on reloads (restoring state on reload of app, or just loading the panel again after splitting right or down) we get the correct syntax highlighting.