### PR TITLE
Rework `link` widget `ref` field

### DIFF
--- a/changelog.d/skieffer.link-ref-field.branchnews.changed.txt
+++ b/changelog.d/skieffer.link-ref-field.branchnews.changed.txt
@@ -1,0 +1,1 @@
+Require proper libpaths (not strings) in `link` widget `ref` field.

--- a/server/pfsc/handlers/study.py
+++ b/server/pfsc/handlers/study.py
@@ -143,11 +143,11 @@ anno {{pagename}} @@@
 study_page_anno_section_template = jinja2.Template('''
 ## Page
 
-<link:>[`{{ai.anno_name}}`]{tab:"other", ref:"{{ai.anno_name}}"}
+<link:>[`{{ai.anno_name}}`]{tab:"other", ref:{{ai.anno_name}}}
 
 ## Goals
 {% for goal_name, origin in ai.goal_widgets %}
-<goal:>[]{altpath:"{{ai.anno_name}}.{{goal_name}}", origin:"{{origin}}"} <link:>[`{{goal_name}}`]{tab:"other", ref:"{{ai.anno_name}}.{{goal_name}}"}
+<goal:>[]{altpath:"{{ai.anno_name}}.{{goal_name}}", origin:"{{origin}}"} <link:>[`{{goal_name}}`]{tab:"other", ref:{{ai.anno_name}}.{{goal_name}}}
 {% if notes[origin] %}
 {{notes[origin]}}
 {% endif %}

--- a/server/pfsc/lang/nodelabels.py
+++ b/server/pfsc/lang/nodelabels.py
@@ -19,7 +19,7 @@ import re, json
 from markupsafe import Markup
 
 from pfsc.lang.widgets import LinkWidget
-from pfsc.lang.freestrings import MathRenderer, PfscRenderer, lookup_link_and_img_policy
+from pfsc.lang.freestrings import MathRenderer, PfscRenderer, lookup_link_and_img_policy, Libpath
 from pfsc.build.lib.libpath import expand_multipath
 from pfsc.excep import PfscExcep, PECode
 from pfsc.util import unindent
@@ -130,7 +130,8 @@ def writeNodelinkHTML(label, libpaths, versions):
 
 
 def writeAnnolinkHTML(url, label, node, link_num):
-    libpath = url[len('notes:'):]
+    libpath_str = url[len('notes:'):]
+    libpath = Libpath(libpath_str)
     lw = LinkWidget(f'_x{link_num}', '', {'ref': libpath, 'tab': 'other'}, node, 0)
     lw.cascadeLibpaths()
     lw.resolve()

--- a/server/pfsc/lang/widgets.py
+++ b/server/pfsc/lang/widgets.py
@@ -1166,6 +1166,7 @@ class LinkWidget(NavWidget):
             "REQ": {
                 'ref': {
                     'type': IType.RELPATH,
+                    'is_Libpath_instance': True,
                 },
             },
             "OPT": {


### PR DESCRIPTION
## Breaking

* Require proper libpaths (not strings) in `link` widget `ref` field.