### PR TITLE
Repair node annolinks

### DIFF
--- a/changelog.d/skieffer.repair-node-annolinks.branchnews.fixed.txt
+++ b/changelog.d/skieffer.repair-node-annolinks.branchnews.fixed.txt
@@ -1,0 +1,1 @@
+Repair node --> anno link click functionality.

--- a/client/src/plugins/MooseNodeLabelPlugin.js
+++ b/client/src/plugins/MooseNodeLabelPlugin.js
@@ -67,7 +67,10 @@ export class MooseNodeLabelPlugin {
             const infoText = infoNode.innerText;
             const info = JSON.parse(infoText);
             const widget = this.hub.notesManager.constructWidget(info);
-            annolink.addEventListener('click', widget.onClick.bind(widget));
+            const pane = this.hub.contentManager.getSurroundingPane(annolink);
+            annolink.addEventListener('click', event => {
+                widget.onClick(event, pane);
+            });
         }
     }
 

--- a/server/pfsc/lang/nodelabels.py
+++ b/server/pfsc/lang/nodelabels.py
@@ -135,6 +135,7 @@ def writeAnnolinkHTML(url, label, node, link_num):
     lw = LinkWidget(f'_x{link_num}', '', {'ref': libpath, 'tab': 'other'}, node, 0)
     lw.cascadeLibpaths()
     lw.resolve()
+    lw.enrich_data()
     data = lw.writeData()
     d = json.dumps(data)
     h = '<span class="annolink customlink">%s<span class="annolinkInfo" style="display:none;">%s</span></span>' % (


### PR DESCRIPTION
Click functionality on links from nodes to annotations was broken. Now repaired.