### PR TITLE
Make `try_to_proxy()` func tolerate network errors

### DIFF
--- a/changelog.d/skieffer.tolerate-network-errors.branchnews.fixed.txt
+++ b/changelog.d/skieffer.tolerate-network-errors.branchnews.fixed.txt
@@ -1,0 +1,2 @@
+The OCA now fails gracefully when checking for updates, if you have
+no internet connection. (Previously, reported a 500 error.)


### PR DESCRIPTION
The OCA now fails gracefully when checking for updates, if you have
no internet connection. (Previously, reported a 500 error.)