### PR TITLE
Make the startup sync check opt-in only

### DIFF
--- a/changelog.d/skieffer.opt-in-sync-check.branchnews.fixed.txt
+++ b/changelog.d/skieffer.opt-in-sync-check.branchnews.fixed.txt
@@ -1,0 +1,4 @@
+Make the new startup sync check introduced in v0.30.0 opt-in only.
+This prevents possible race conditions between one process performing
+startup cleanup of the build directory, while another process is
+attempting to build new output.

--- a/server/pfsc/blueprints/cli.py
+++ b/server/pfsc/blueprints/cli.py
@@ -29,7 +29,7 @@ from pygit2 import clone_repository, GitError, RemoteCallbacks
 
 import pfsc.constants
 from pfsc.constants import UserProps
-from pfsc import pfsc_cli, make_app
+from pfsc import pfsc_cli, make_app, get_app
 from pfsc.build import build_repo
 from pfsc.build.repo import RepoInfo
 from pfsc.checkinput import check_type, IType
@@ -74,9 +74,7 @@ def build(repopath, tag, clean, verbose=False, auto_deps=False, debug=False):
     Build the proofscape repo at REPOPATH.
     """
     try:
-        # By invoking the `make_app` function with no arguments, we allow it to
-        # determine the configuration based on the FLASK_CONFIG environment variable.
-        app = make_app()
+        app, _ = get_app()
         # However we force PSM, since when you are working from the CLI you should
         # be able to do whatever you want.
         app.config["PERSONAL_SERVER_MODE"] = True

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -34,7 +34,7 @@ os.environ["FLASK_CONFIG"] = testing_config
 
 
 def make_test_app():
-    return make_app(testing_config)
+    return make_app(testing_config, sync_check=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
There are situations in which multiple apps are formed (for example in [pfsc-repo-build-action](https://github.com/proofscape/pfsc-repo-build-action)).
In such cases, automatically doing the sync check with cleanup actions can lead to bad race conditions
(e.g. competing with build operations).

To avoid such issues, the check + cleanup is now opt-in only, and we currently opt in only in the app provided for unit tests in `conftest.py`.

While we're at it, we also switch to use of `get_app()` instead of `make_app()` in the implementation of the `flask pfsc build` CLI command. There's no need for a new app here.