### PR TITLE
c: Bugfix in `RepoManager`

### DIFF
--- a/client/src/trees/RepoManager.js
+++ b/client/src/trees/RepoManager.js
@@ -527,7 +527,7 @@ export class RepoManager {
     /* Check whether a repo is marked as being trusted site-wide.
      */
     repoIsTrustedSiteWide(repopath, version) {
-        const repopathv = iseUtil.lv(repopath, "WIP");
+        const repopathv = iseUtil.lv(repopath, version);
         const loaded = this.repoIsLoaded({repopathv});
         let item = {};
         if (loaded.fs) {


### PR DESCRIPTION
The `repoIsTrustedSiteWide()` method (new in this release cycle) had a hard-coded "WIP" version, which should have been the passed `version` arg. (Looks like a copy-paste error.)