### PR TITLE
c: Bugfix in checking of site-wide repo trust settings

### DIFF
--- a/changelog.d/skieffer.fix-repo-mgr-trust-check-2.branchnews.fixed.txt
+++ b/changelog.d/skieffer.fix-repo-mgr-trust-check-2.branchnews.fixed.txt
@@ -1,0 +1,3 @@
+Ensure that site-wide repo trust settings are correctly reflected for
+content that is loaded without its repo currently being open in the
+sidebar.

--- a/client/src/mgr/TrustManager.js
+++ b/client/src/mgr/TrustManager.js
@@ -182,7 +182,8 @@ export class TrustManager {
      *   RepoManager.repoIsTrustedSiteWide()
      */
     async checkCombinedTrustSetting(repopath, version) {
-        if (this.hub.repoManager.repoIsTrustedSiteWide(repopath, version)) {
+        const siteWide = await this.hub.repoManager.repoIsTrustedSiteWide(repopath, version);
+        if (siteWide) {
             return true;
         }
         return await this.checkPerUserTrustSetting(repopath, version);


### PR DESCRIPTION
The existing method for checking trust on a page of content relied on the repo to which that page belongs being open in the sidebar. We repair this so that the repo need not be open.