### PR TITLE
Improve `pfsc deploy generate` command

### DIFF
--- a/.github/workflows/pise-build-and-test.yml
+++ b/.github/workflows/pise-build-and-test.yml
@@ -435,6 +435,7 @@ jobs:
               -n 1 --demos \
               --dirname ${{ env.TEST_DEPLOY_DIR }} \
               --flask-config dockerdev \
+              --no-per-deploy-dirs \
               --lib-vol=${{ env.LIB_VOLUME }} \
               --build-vol=${{ env.BUILD_VOLUME }} \
               --gdb-vol=${{ env.GDB_VOLUME }}

--- a/manage/tools/deploy/__init__.py
+++ b/manage/tools/deploy/__init__.py
@@ -108,8 +108,8 @@ def production(gdb, workers, demos, dump_dc, dirname, official, pfsc_tag):
               help='Use `pise:TEXT` docker image.')
 @click.option('--official', is_flag=True, help='Use official docker images under "proofscape/"')
 @click.option('-n', '--workers', type=int, default=1, prompt='How many RQ workers', help='Number of worker containers you want to run')
-@click.option('--demos/--no-demos', default=False, prompt='Serve demo repos', help="Serve demo repos.")
-@click.option('--mount-code/--no-mount-code', default=False, prompt='Volume-mount code for development',
+@click.option('--demos/--no-demos', default=True, prompt='Serve demo repos', help="Serve demo repos.")
+@click.option('--mount-code/--no-mount-code', default=True, prompt='Volume-mount code for development',
               help='Volume-mount code (server,client,pdf,pyodide,whl) for live updates during development.')
 @click.option('--mount-pkg', default=None,
               help='Volume-mount pkg dir TEXT from local venv, e.g. for testing upgrade before docker rebuild. May be comma-delimited list.')


### PR DESCRIPTION
* Set the default values for `--demos` and `--mount-code` to `True`, which is the normal setup for testing.
* Add a `--per-deploy-dirs` setting, which defaults to `True`, meaning that the `lib`, `build`, and `graphdb`
  dirs mounted into the containers for both MCA and OCA will be "per deployment," i.e. instead of being the
  system-wide dirs, they will be ones living under the generated deployment directory. This helps keep testing
  localized.