### PR TITLE
s: Halt build on pfsc- directives with bad opt block in Sphinx pages

### DIFF
--- a/changelog.d/skieffer.catch-invalid-opt-block.branchnews.improved.txt
+++ b/changelog.d/skieffer.catch-invalid-opt-block.branchnews.improved.txt
@@ -1,0 +1,2 @@
+Provide a helpful error message in case of invalid option blocks
+in pfsc directives in Sphinx pages.

--- a/server/tests/resources/repo/spx/err/v0.3.0/conf.py
+++ b/server/tests/resources/repo/spx/err/v0.3.0/conf.py
@@ -1,0 +1,29 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../..'))
+
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'sphinx-proofscape doc with errors'
+copyright = '2024, author'
+author = 'author'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = []
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'venv']
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+#html_theme = 'alabaster'
+#html_static_path = ['_static']

--- a/server/tests/resources/repo/spx/err/v0.3.0/index.rst
+++ b/server/tests/resources/repo/spx/err/v0.3.0/index.rst
@@ -1,0 +1,30 @@
+sphinx-proofscape doc with errors
+=================================
+
+.. pfsc::
+
+    deduc Thm {
+        asrt C {
+            sy="C"
+        }
+        meson = "C"
+    }
+
+    deduc Pf of Thm.C {
+        asrt R {
+            sy="R"
+        }
+        asrt S {
+            sy="S"
+        }
+        meson = "R, so S, therefore Thm.C."
+    }
+
+This chart widget has an error, because the ``viewOpts`` field uses
+improper indentation. (The closing brace needs to be further indented.)
+
+.. pfsc-chart::
+    :view: Thm.C
+    :viewOpts: {
+        transition: false,
+    }

--- a/server/tests/test_widgets.py
+++ b/server/tests/test_widgets.py
@@ -459,36 +459,36 @@ Expected one of:
 
 .. pfsc-chart::
     :view: Thm.C, Pf.{R,S}
-""".strip()
-
-@pytest.mark.psm
-def test_sphinx_directive_widget_field_pf_json_parse_err(app):
-    """
-    Check that we get the expected error message when we try to build a Sphinx
-    page in which a widget (in directive form) field has a PF-JSON parse error.
-    """
-    with app.app_context():
-        with pytest.raises(PfscExcep) as ei:
-            build_repo('test.spx.err', version='v0.1.0', quiet=True)
-        pe = ei.value
-        s = str(pe)
-        n = s.find(spx_err_txt_1)
-        assert n > 0
+"""
 
 spx_err_txt_2 = """
 /lib/test/spx/err/index.rst:23:PROOFSCAPE-SPHINX-ERROR: Inline Proofscape chart widgets must have the form `SUBTEXT &lt;VIEW&gt;`.
-""".strip()
+"""
+
+spx_err_txt_3 = """
+/lib/test/spx/err/index.rst:26:Error in &#34;pfsc-chart&#34; directive:
+invalid option block.
+"""
 
 @pytest.mark.psm
-def test_sphinx_role_widget_malformed(app):
+@pytest.mark.parametrize('version, err_msg', [
+    # A widget in directive form has a field with a PF-JSON parse error.
+    ['v0.1.0', spx_err_txt_1],
+    # A widget in role form has malformed interpreted text.
+    ['v0.2.0', spx_err_txt_2],
+    # A widget in directive form uses improper indentation in its option block.
+    ['v0.3.0', spx_err_txt_3],
+])
+def test_sphinx_widget_errors(app, version, err_msg):
     """
-    Check that we get the expected error message when we try to build a Sphinx
-    page in which a widget in role form has malformed interpreted text.
+    Check that we get the expected error messages when we try to build a Sphinx
+    pages with malformed widgets.
     """
     with app.app_context():
         with pytest.raises(PfscExcep) as ei:
-            build_repo('test.spx.err', version='v0.2.0', quiet=True)
+            build_repo('test.spx.err', version=version, quiet=True)
         pe = ei.value
         s = str(pe)
-        n = s.find(spx_err_txt_2)
+        print('\n', s)
+        n = s.find(err_msg.strip())
         assert n > 0


### PR DESCRIPTION
It will likely be a common error in Sphinx pages, to have an invalid option block in `pfsc-` directives whenever a PF-JSON *object* is the value of any of the data fields. This is because there may be a tendency to indent the closing brace in line with the option name, like this:
```rst
.. pfsc-chart::
    :view: Thm.C
    :viewOpts: {
        transition: false,
    }
```
whereas in fact it needs to be indented deeper than the option name, like this:

```rst
.. pfsc-chart::
    :view: Thm.C
    :viewOpts: {
        transition: false,
        }
```

Up to now, an error of this kind, which Sphinx calls an "invalid option block" is simply reported by Sphinx as a *warning*, which does not halt the build process. In such a case, the widget simply produces no HTML whatsoever. This means you can have a "successful" build, and yet wind up with a Sphinx page in which one or more of your widgets simply does not appear at all.

We now elevate such Sphinx warnings to actual build-halting errors, so that the user is made aware of the issue.