### PR TITLE
Rework deployment directory names

### DIFF
--- a/manage/tools/deploy/__init__.py
+++ b/manage/tools/deploy/__init__.py
@@ -932,9 +932,9 @@ def make_new_deployment_dir(desired_name=None, prefix=None):
         msg = f'The deployment dir `{desired_name}` already exists.'
         raise click.UsageError(msg)
     elif desired_name is None:
-        from tools.word import random_adj_and_name
-        adj, name = random_adj_and_name(dodge_prefixes=existing_names)
-        new_dir_name = f'{adj}_{name}_{simple_timestamp()}'
+        from tools.word import random_math_name
+        math_name = random_math_name(dodge_prefixes=existing_names)
+        new_dir_name = f'{math_name}_{simple_timestamp()}'
         if prefix:
             new_dir_name = prefix + new_dir_name
     else:

--- a/manage/tools/word.py
+++ b/manage/tools/word.py
@@ -14,164 +14,45 @@
 #   limitations under the License.                                            #
 # --------------------------------------------------------------------------- #
 
-import os
 import random
 
 
-def random_adj_and_name(dodge_prefixes=None):
+def random_math_name(dodge_prefixes=None):
     """
-    Choose a random adjective and mathematician name.
+    Choose a random mathematician name.
 
-    All adjectives have unique three-letter prefixes.
+    All names have unique three-letter prefixes.
 
     :param dodge_prefixes: optional list of strings. If provided, we will
-      choose an adjective that is not a prefix of any of these strings.
+      choose a name that is not a prefix of any of these strings.
 
-    :return: pair (adj, name)
+    :return: string
     """
     dodge_prefixes = list(sorted(dodge_prefixes or []))
     d_ptr = 0
-    a_ptr = 0
+    n_ptr = 0
     reject = set()
-    while d_ptr < len(dodge_prefixes) and a_ptr < len(adjectives):
+    while d_ptr < len(dodge_prefixes) and n_ptr < len(mathematicians):
         d = dodge_prefixes[d_ptr]
-        a = adjectives[a_ptr]
-        if a > d:
+        n = mathematicians[n_ptr]
+        if n > d:
             d_ptr += 1
             continue
-        if d.startswith(a):
-            reject.add(a)
-        a_ptr += 1
+        if d.startswith(n):
+            reject.add(n)
+        n_ptr += 1
     if reject:
-        adjs = list(set(adjectives) - reject)
+        names = list(set(mathematicians) - reject)
     else:
-        adjs = adjectives
+        names = mathematicians
 
-    if not adjs:
-        raise Exception('Ran out of adjectives! You have too many deployment dirs!')
+    if not names:
+        raise Exception('Ran out of names! Maybe you have too many deployment dirs!')
 
-    adj = random.choice(adjs)
-    name = random.choice(mathematicians)
+    name = random.choice(names)
 
-    return adj, name
+    return name
 
-
-adjectives = """
-accomplished
-adaptable
-adept
-adventurous
-affable
-agreeable
-amazing
-ambitious
-amiable
-amusing
-approachable
-articulate
-awesome
-blithesome
-brave
-brilliant
-calm
-capable
-careful
-charming
-cheerful
-confident
-courageous
-creative
-dazzling
-decisive
-dependable
-determined
-devoted
-diligent
-diplomatic
-discreet
-dynamic
-educated
-efficient
-elegant
-enchanting
-energetic
-engaging
-enlightened
-enthusiastic
-excellent
-expert
-exuberant
-faithful
-fantastic
-fearless
-flexible
-focused
-friendly
-generous
-gleaming
-glittering
-glowing
-good
-gregarious
-helpful
-hilarious
-honest
-humorous
-imaginative
-impartial
-incredible
-independent
-inquisitive
-insightful
-intelligent
-inventive
-kind
-knowledgeable
-likable
-loyal
-magnificent
-marvelous
-mirthful
-observant
-optimistic
-organized
-outstanding
-patient
-persistent
-philosophical
-pioneering
-placid
-plucky
-polite
-powerful
-practical
-productive
-quiet
-rational
-reliable
-remarkable
-resourceful
-sensible
-sincere
-sociable
-spectacular
-splendid
-stellar
-straightforward
-stupendous
-super
-sympathetic
-thoughtful
-tidy
-trustworthy
-understanding
-unique
-upbeat
-versatile
-vibrant
-witty
-wonderful
-""".split()
 
 mathematicians = """
 abel
@@ -179,34 +60,26 @@ artin
 babbage
 bachmann
 banach
-bernays
 berwick
 bessel
 betti
 bezout
 blaschke
-bolyai
 bolzano
 bonferroni
 boole
-borchardt
 borel
 brouwer
 burnside
 byron
 cantor
-caratheodory
-carmichael
 cartan
-casorati
 cassels
 catalan
 cauchy
 cayley
 cesaro
-chebotaryov
 chebyshev
-chevalley
 clebsch
 conway
 courant
@@ -228,7 +101,6 @@ fano
 fermat
 fourier
 fraenkel
-frechet
 frege
 fricke
 frobenius
@@ -268,7 +140,6 @@ kummer
 kuratowski
 kutta
 lagrange
-laguerre
 landau
 laplace
 lasker
@@ -278,8 +149,6 @@ lefschetz
 legendre
 lehmer
 libri
-lie
-lindelof
 lindemann
 liouville
 lissajous
@@ -308,17 +177,13 @@ peano
 peirce
 pell
 picard
-pluecker
 poincare
-poinsot
-poisson
 polya
 poussin
 puiseux
 pythagoras
 raabe
 ramanujan
-ramchundra
 riemann
 roch
 ruffini
@@ -331,15 +196,12 @@ serret
 severi
 shanks
 siegel
-sierpinski
 skolem
 steinitz
 stieltjes
 stokes
-study
 sturm
 sylow
-sylvester
 takagi
 taussky
 thue
@@ -369,19 +231,22 @@ zolotarev
 ###########
 
 def test00():
-    assert adjectives == list(sorted(adjectives))
+    assert mathematicians == list(sorted(mathematicians))
+
 
 def test01():
     for k in range(10):
-        print(random_adj_and_name())
+        print(random_math_name())
+
 
 def test02():
     """
     Show that the `dodge_prefixes` feature works.
     """
-    dodge = list(set(adjectives) - set(['good']))
-    a, n = random_adj_and_name(dodge_prefixes=dodge)
-    assert a == 'good'
+    dodge = list(set(mathematicians) - {'venn'})
+    name = random_math_name(dodge_prefixes=dodge)
+    assert name == 'venn'
+
 
 if __name__ == "__main__":
     test02()


### PR DESCRIPTION
Remove the adjectives; just use the mathematician names. In practice we have no need of that many combinations.

Also prune the name list so there are no three-letter prefix collisions.